### PR TITLE
playlist democracy: option to not skip when the queue is empty

### DIFF
--- a/packages/plugin-playlist-democracy/schema.ts
+++ b/packages/plugin-playlist-democracy/schema.ts
@@ -105,6 +105,8 @@ export function getConfigSchema(): PluginConfigSchema {
       "thresholdValue",
       percentExampleBlock,
       staticExampleBlock,
+      "skipRequiresQueue",
+      "skipRequiresQueueMin",
     ],
     fieldMeta: {
       enabled: {
@@ -142,6 +144,22 @@ export function getConfigSchema(): PluginConfigSchema {
         label: "Threshold Value",
         description: "Percentage of listeners (1-100%) or number of reactions needed",
         showWhen: { field: "enabled", value: true },
+      },
+      skipRequiresQueue: {
+        type: "boolean",
+        label: "Only skip when queue has tracks",
+        description:
+          "When enabled, tracks will not be skipped if the queue has too few tracks waiting",
+        showWhen: { field: "enabled", value: true },
+      },
+      skipRequiresQueueMin: {
+        type: "number",
+        label: "Minimum queue length to skip",
+        description: "Tracks will only be skipped if the queue has more than this many tracks",
+        showWhen: [
+          { field: "enabled", value: true },
+          { field: "skipRequiresQueue", value: true },
+        ],
       },
     },
   }

--- a/packages/plugin-playlist-democracy/types.ts
+++ b/packages/plugin-playlist-democracy/types.ts
@@ -28,5 +28,5 @@ export const defaultPlaylistDemocracyConfig: PlaylistDemocracyConfig = {
   thresholdType: "percentage",
   thresholdValue: 50,
   skipRequiresQueue: false,
-  skipRequiresQueueMin: 1,
+  skipRequiresQueueMin: 0,
 }

--- a/packages/plugin-playlist-democracy/types.ts
+++ b/packages/plugin-playlist-democracy/types.ts
@@ -9,6 +9,8 @@ export const playlistDemocracyConfigSchema = z.object({
   timeLimit: z.number().min(10000).max(300000), // milliseconds (10s - 5min)
   thresholdType: z.enum(["percentage", "static"]),
   thresholdValue: z.number().min(1).max(100), // 0-100 for percentage, absolute number for static
+  skipRequiresQueue: z.boolean(), // only skip when queue has enough tracks
+  skipRequiresQueueMin: z.number().min(0), // minimum queue length required to skip
 })
 
 /**
@@ -25,4 +27,6 @@ export const defaultPlaylistDemocracyConfig: PlaylistDemocracyConfig = {
   timeLimit: 60000, // 60 seconds
   thresholdType: "percentage",
   thresholdValue: 50,
+  skipRequiresQueue: false,
+  skipRequiresQueueMin: 1,
 }

--- a/packages/server/lib/plugins/PluginAPI.ts
+++ b/packages/server/lib/plugins/PluginAPI.ts
@@ -143,6 +143,11 @@ export class PluginAPIImpl implements PluginAPI {
     })
   }
 
+  async getQueue(roomId: string): Promise<QueueItem[]> {
+    const { getQueue } = await import("../../operations/data")
+    return await getQueue({ context: this.context, roomId })
+  }
+
   /**
    * Emit a custom plugin event.
    * Events are namespaced as PLUGIN:{pluginName}:{eventName}

--- a/packages/types/Plugin.ts
+++ b/packages/types/Plugin.ts
@@ -180,6 +180,8 @@ export interface PluginAPI {
   setPluginConfig(roomId: string, pluginName: string, config: any): Promise<void>
   /** Emit an update for a playlist track (e.g., when pluginData changes) */
   updatePlaylistTrack(roomId: string, track: QueueItem): Promise<void>
+  /** Get the current queue for a room */
+  getQueue(roomId: string): Promise<QueueItem[]>
 
   /**
    * Emit a custom plugin event.


### PR DESCRIPTION
Adds "skip requires queue" and "minimum queue length" options for preventing skips when there's no (or low) queue

closes #70 