### PR TITLE
Plugin: Guess the Tune

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,8 @@ npm run dev
 # Run tests
 npm test
 
+Uses `turbo run test --continue=always` so one failing package (e.g. server tests on an older Node than `packages/server`’s `engines`) does not skip the rest of the workspaces. For a single package: `npm test -w @repo/plugin-guess-the-tune`.
+
 # Lint
 npm run lint
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,6 +20,7 @@
     "@repo/media-source-rtmp": "*",
     "@repo/plugin-absent-dj": "*",
     "@repo/plugin-queue-hygiene": "*",
+    "@repo/plugin-guess-the-tune": "*",
     "@repo/plugin-special-words": "*",
     "@repo/plugin-playlist-democracy": "*",
     "@repo/server": "*",

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -17,6 +17,7 @@ import createPlaylistDemocracyPlugin from "@repo/plugin-playlist-democracy"
 import createSpecialWordsPlugin from "@repo/plugin-special-words"
 import createAbsentDjPlugin from "@repo/plugin-absent-dj"
 import createQueueHygienePlugin from "@repo/plugin-queue-hygiene"
+import createGuessTheTunePlugin from "@repo/plugin-guess-the-tune"
 import { authHandler } from "@repo/auth/server"
 import { requireAdmin } from "@repo/auth/middleware"
 
@@ -73,6 +74,7 @@ async function main() {
       createSpecialWordsPlugin,
       createAbsentDjPlugin,
       createQueueHygienePlugin,
+      createGuessTheTunePlugin,
     ],
   })
 

--- a/apps/web/src/components/NowPlaying/NowPlayingTrack.tsx
+++ b/apps/web/src/components/NowPlaying/NowPlayingTrack.tsx
@@ -24,6 +24,9 @@ import { usePluginStyles } from "../../hooks/usePluginStyles"
 import { usePluginElementProps } from "../../hooks/usePluginElementProps"
 import { usePreferredMetadataSource } from "../../hooks/useActors"
 import { MetadataSourceType } from "../../types/Queue"
+import type { PluginElementProps } from "@repo/types"
+
+type RevealedBy = NonNullable<PluginElementProps["revealedBy"]>
 
 interface NowPlayingTrackProps {
   meta: RoomMeta
@@ -225,6 +228,11 @@ export function NowPlayingTrack({ meta, room, users }: NowPlayingTrackProps) {
 
 // Sub-components
 
+function guessRevealCreditLine(revealedBy: RevealedBy): string {
+  const name = revealedBy.username?.trim() || "someone"
+  return revealedBy.source === "admin" ? `Revealed by ${name}` : `Identified by ${name}`
+}
+
 const shimmerCss = {
   "@keyframes nowPlayingShimmer": {
     "0%": { opacity: 0.35 },
@@ -238,7 +246,7 @@ interface ObscuredTitleBlockProps {
   children: string | null
   obscured: boolean
   placeholder?: string
-  revealedBy?: { userId: string; username: string; at: number } | null
+  revealedBy?: RevealedBy | null
   externalUrl: string | null
   pluginStyles: React.CSSProperties
 }
@@ -270,7 +278,7 @@ function ObscuredTitleBlock({
   const credit =
     revealedBy != null ? (
       <Text fontSize="2xs" color="primary.contrast/55" mt={1}>
-        Identified by {revealedBy.username ?? "someone"}
+        {guessRevealCreditLine(revealedBy)}
       </Text>
     ) : null
 
@@ -301,7 +309,7 @@ interface ObscuredTextBlockProps {
   children: string
   obscured: boolean
   placeholder?: string
-  revealedBy?: { userId: string; username: string; at: number } | null
+  revealedBy?: RevealedBy | null
   /** Use heading styles for artist line */
   asHeading?: boolean
 }
@@ -348,7 +356,7 @@ function ObscuredTextBlock({
   const credit =
     revealedBy != null ? (
       <Text fontSize="2xs" color="primary.contrast/45" mt={0.5}>
-        Identified by {revealedBy.username ?? "someone"}
+        {guessRevealCreditLine(revealedBy)}
       </Text>
     ) : null
 

--- a/apps/web/src/components/NowPlaying/NowPlayingTrack.tsx
+++ b/apps/web/src/components/NowPlaying/NowPlayingTrack.tsx
@@ -10,6 +10,7 @@ import {
   Stack,
   Icon,
   Box,
+  Image,
 } from "@chakra-ui/react"
 import { format } from "date-fns"
 
@@ -20,6 +21,7 @@ import { User } from "../../types/User"
 import { Room, RoomMeta } from "../../types/Room"
 import { PluginArea } from "../PluginComponents"
 import { usePluginStyles } from "../../hooks/usePluginStyles"
+import { usePluginElementProps } from "../../hooks/usePluginElementProps"
 import { usePreferredMetadataSource } from "../../hooks/useActors"
 import { MetadataSourceType } from "../../types/Queue"
 
@@ -28,6 +30,23 @@ interface NowPlayingTrackProps {
   room: Partial<Room> | null
   users: User[]
 }
+
+/** Neutral “hidden artwork” placeholder (SVG data URI — no network). */
+const OBSCURED_ARTWORK_PLACEHOLDER =
+  "data:image/svg+xml;charset=utf-8," +
+  encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+      <defs>
+        <linearGradient id="obArtG" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stop-color="#3d3d48"/>
+          <stop offset="100%" stop-color="#26262e"/>
+        </linearGradient>
+      </defs>
+      <rect width="512" height="512" fill="url(#obArtG)"/>
+      <circle cx="256" cy="256" r="132" fill="none" stroke="#5c5c6a" stroke-width="10"/>
+      <circle cx="256" cy="256" r="48" fill="#5c5c6a"/>
+    </svg>`,
+  )
 
 function getCoverUrl(release: any, room: Partial<Room> | null): string | null {
   const useRoomArtwork = room?.artwork && (!room.artworkStreamingOnly || !room.fetchMeta)
@@ -104,6 +123,11 @@ export function NowPlayingTrack({ meta, room, users }: NowPlayingTrackProps) {
   // Get plugin-provided styles for the title
   const titleStyles = usePluginStyles(nowPlaying?.pluginData, "title")
 
+  const titleElementProps = usePluginElementProps(nowPlaying?.pluginData, "title")
+  const artistElementProps = usePluginElementProps(nowPlaying?.pluginData, "artist")
+  const albumElementProps = usePluginElementProps(nowPlaying?.pluginData, "album")
+  const artworkElementProps = usePluginElementProps(nowPlaying?.pluginData, "artwork")
+
   const djUsername = useMemo(
     () =>
       dj
@@ -129,24 +153,54 @@ export function NowPlayingTrack({ meta, room, users }: NowPlayingTrackProps) {
               <Box position="absolute">
                 <PluginArea area="nowPlayingArt" color="primaryBg" />
               </Box>
-              <AlbumArtwork coverUrl={coverUrl} />
+              <Box position="relative" overflow="hidden" borderRadius="md" height="100%" width="100%">
+                {artworkElementProps.obscured ? (
+                  <Image
+                    src={OBSCURED_ARTWORK_PLACEHOLDER}
+                    alt=""
+                    height="100%"
+                    width="100%"
+                    objectFit="cover"
+                    draggable={false}
+                  />
+                ) : (
+                  <AlbumArtwork coverUrl={coverUrl} />
+                )}
+              </Box>
             </Box>
           )}
           <VStack align="start" gap={0}>
-            <TrackTitle title={titleDisplay} externalUrl={externalUrl} pluginStyles={titleStyles} />
+            <ObscuredTitleBlock
+              obscured={titleElementProps.obscured}
+              placeholder={titleElementProps.placeholder}
+              revealedBy={titleElementProps.revealedBy}
+              externalUrl={externalUrl}
+              pluginStyles={titleStyles}
+            >
+              {titleDisplay}
+            </ObscuredTitleBlock>
 
             <PluginArea area="nowPlayingBadge" />
 
             {artist && (
-              <Heading color="primary.contrast" margin="none" as="h4" size="sm">
+              <ObscuredTextBlock
+                obscured={artistElementProps.obscured}
+                placeholder={artistElementProps.placeholder}
+                revealedBy={artistElementProps.revealedBy}
+                asHeading
+              >
                 {artist}
-              </Heading>
+              </ObscuredTextBlock>
             )}
 
             {album && (
-              <Text as="span" color="primary.contrast/50" margin="none" fontSize="xs">
+              <ObscuredTextBlock
+                obscured={albumElementProps.obscured}
+                placeholder={albumElementProps.placeholder}
+                revealedBy={albumElementProps.revealedBy}
+              >
                 {album}
-              </Text>
+              </ObscuredTextBlock>
             )}
 
             {releaseDate && (
@@ -171,13 +225,32 @@ export function NowPlayingTrack({ meta, room, users }: NowPlayingTrackProps) {
 
 // Sub-components
 
-interface TrackTitleProps {
-  title: string | null
+const shimmerCss = {
+  "@keyframes nowPlayingShimmer": {
+    "0%": { opacity: 0.35 },
+    "50%": { opacity: 0.95 },
+    "100%": { opacity: 0.35 },
+  },
+  animation: "nowPlayingShimmer 2.2s ease-in-out infinite",
+}
+
+interface ObscuredTitleBlockProps {
+  children: string | null
+  obscured: boolean
+  placeholder?: string
+  revealedBy?: { userId: string; username: string; at: number } | null
   externalUrl: string | null
   pluginStyles: React.CSSProperties
 }
 
-function TrackTitle({ title, externalUrl, pluginStyles }: TrackTitleProps) {
+function ObscuredTitleBlock({
+  children,
+  obscured,
+  placeholder,
+  revealedBy,
+  externalUrl,
+  pluginStyles,
+}: ObscuredTitleBlockProps) {
   const headingStyles = {
     color: "primary.contrast",
     margin: "none",
@@ -185,20 +258,118 @@ function TrackTitle({ title, externalUrl, pluginStyles }: TrackTitleProps) {
     size: ["md", "2xl"] as any,
   }
 
-  if (externalUrl) {
+  if (obscured) {
+    const label = placeholder ?? "???"
     return (
-      <LinkOverlay href={externalUrl} target="_blank" rel="noopener noreferrer">
-        <Heading {...headingStyles} style={pluginStyles}>
-          {title}
-        </Heading>
-      </LinkOverlay>
+      <Heading {...headingStyles} css={shimmerCss} userSelect="none" aria-hidden="true">
+        {label}
+      </Heading>
+    )
+  }
+
+  const credit =
+    revealedBy != null ? (
+      <Text fontSize="2xs" color="primary.contrast/55" mt={1}>
+        Identified by {revealedBy.username ?? "someone"}
+      </Text>
+    ) : null
+
+  if (externalUrl && children) {
+    return (
+      <>
+        <LinkOverlay href={externalUrl} target="_blank" rel="noopener noreferrer">
+          <Heading {...headingStyles} style={pluginStyles}>
+            {children}
+          </Heading>
+        </LinkOverlay>
+        {credit}
+      </>
     )
   }
 
   return (
-    <Heading {...headingStyles} style={pluginStyles}>
-      {title}
-    </Heading>
+    <>
+      <Heading {...headingStyles} style={pluginStyles}>
+        {children}
+      </Heading>
+      {credit}
+    </>
+  )
+}
+
+interface ObscuredTextBlockProps {
+  children: string
+  obscured: boolean
+  placeholder?: string
+  revealedBy?: { userId: string; username: string; at: number } | null
+  /** Use heading styles for artist line */
+  asHeading?: boolean
+}
+
+function ObscuredTextBlock({
+  children,
+  obscured,
+  placeholder,
+  revealedBy,
+  asHeading,
+}: ObscuredTextBlockProps) {
+  if (obscured) {
+    const label = placeholder ?? "???"
+    if (asHeading) {
+      return (
+        <Heading
+          color="primary.contrast"
+          margin="none"
+          as="h4"
+          size="sm"
+          css={shimmerCss}
+          userSelect="none"
+          aria-hidden="true"
+        >
+          {label}
+        </Heading>
+      )
+    }
+    return (
+      <Text
+        as="span"
+        color="primary.contrast/50"
+        margin="none"
+        fontSize="xs"
+        css={shimmerCss}
+        userSelect="none"
+        aria-hidden="true"
+      >
+        {label}
+      </Text>
+    )
+  }
+
+  const credit =
+    revealedBy != null ? (
+      <Text fontSize="2xs" color="primary.contrast/45" mt={0.5}>
+        Identified by {revealedBy.username ?? "someone"}
+      </Text>
+    ) : null
+
+  if (asHeading) {
+    return (
+      <Box>
+        <Heading color="primary.contrast" margin="none" as="h4" size="sm">
+          {children}
+        </Heading>
+        {credit}
+      </Box>
+    )
+  }
+
+  return (
+    <Box>
+      <Text as="span" color="primary.contrast/50" margin="none" fontSize="xs">
+        {children}
+      </Text>
+      {credit}
+    </Box>
   )
 }
 

--- a/apps/web/src/hooks/usePluginElementProps.ts
+++ b/apps/web/src/hooks/usePluginElementProps.ts
@@ -1,0 +1,96 @@
+import { useMemo } from "react"
+import type {
+  PluginElementKey,
+  PluginElementProps,
+  PluginObscureBypassRole,
+} from "@repo/types"
+
+import {
+  useIsAdmin,
+  useIsRoomCreator,
+  useCanAddToQueue,
+} from "./useActors"
+
+/**
+ * Roles the current viewer has, for resolving {@link PluginElementProps.obscureBypassRoles}.
+ */
+function usePluginObscureViewerRoles(): PluginObscureBypassRole[] {
+  const isAdmin = useIsAdmin()
+  const isCreator = useIsRoomCreator()
+  const isDj = useCanAddToQueue()
+
+  return useMemo(() => {
+    const roles: PluginObscureBypassRole[] = []
+    if (isAdmin) roles.push("admin")
+    if (isCreator) {
+      roles.push("creator")
+      roles.push("owner")
+    }
+    if (isDj) roles.push("dj")
+    return roles
+  }, [isAdmin, isCreator, isDj])
+}
+
+function mergeRawElementProps(
+  pluginData: Record<string, unknown> | undefined,
+  element: PluginElementKey,
+): PluginElementProps {
+  if (!pluginData) return {}
+
+  const bypass = new Set<PluginObscureBypassRole>()
+  let revealedBy: PluginElementProps["revealedBy"]
+  let anyObscured = false
+  let placeholder: string | undefined
+
+  const names = Object.keys(pluginData).sort()
+  for (const pluginName of names) {
+    const data = pluginData[pluginName] as Record<string, unknown> | undefined
+    const ep = data?.elementProps as Partial<Record<PluginElementKey, PluginElementProps>> | undefined
+    const slice = ep?.[element]
+    if (!slice) continue
+
+    if (slice.obscureBypassRoles?.length) {
+      for (const r of slice.obscureBypassRoles) bypass.add(r)
+    }
+    if (slice.placeholder != null) placeholder = slice.placeholder
+    if (slice.revealedBy) revealedBy = slice.revealedBy
+    if (slice.obscured === true) anyObscured = true
+  }
+
+  const obscured = Boolean(anyObscured && !revealedBy)
+
+  return {
+    obscured,
+    obscureBypassRoles: bypass.size ? Array.from(bypass) : undefined,
+    revealedBy: revealedBy ?? undefined,
+    placeholder,
+  }
+}
+
+export interface ResolvedPluginElementProps extends PluginElementProps {
+  /** Final obscured flag after applying viewer bypass roles */
+  obscured: boolean
+}
+
+/**
+ * Merges `elementProps` from all plugins under `pluginData` and resolves
+ * {@link PluginElementProps.obscureBypassRoles} against the current viewer.
+ */
+export function usePluginElementProps(
+  pluginData: Record<string, unknown> | undefined,
+  element: PluginElementKey,
+): ResolvedPluginElementProps {
+  const viewerRoles = usePluginObscureViewerRoles()
+
+  return useMemo(() => {
+    const raw = mergeRawElementProps(pluginData, element)
+    const bypass =
+      raw.obscured &&
+      raw.obscureBypassRoles?.some((r) => viewerRoles.includes(r))
+
+    return {
+      ...raw,
+      obscured: Boolean(raw.obscured && !bypass),
+    }
+  }, [pluginData, element, viewerRoles])
+}

--- a/apps/web/src/machines/modalsMachine.ts
+++ b/apps/web/src/machines/modalsMachine.ts
@@ -27,6 +27,7 @@ export type Event =
   | { type: "EDIT_SPECIAL_WORDS" }
   | { type: "EDIT_ABSENT_DJ" }
   | { type: "EDIT_QUEUE_HYGIENE" }
+  | { type: "EDIT_GUESS_THE_TUNE" }
   | { type: "NEXT" }
   | { type: "NUKE_USER" }
 
@@ -100,10 +101,12 @@ export const modalsMachine = setup({
             EDIT_SPOTIFY: "spotify",
             EDIT_PASSWORD: "password",
             EDIT_SCHEDULE: "schedule",
+            // Plugin rows in Overview use EDIT_{NAME} (see toEventName); each needs a transition + substate below.
             EDIT_PLAYLIST_DEMOCRACY: "playlist_democracy",
             EDIT_SPECIAL_WORDS: "special_words",
             EDIT_ABSENT_DJ: "absent_dj",
             EDIT_QUEUE_HYGIENE: "queue_hygiene",
+            EDIT_GUESS_THE_TUNE: "guess_the_tune",
           },
         },
         playlist_democracy: {
@@ -122,6 +125,11 @@ export const modalsMachine = setup({
           },
         },
         queue_hygiene: {
+          on: {
+            BACK: "overview",
+          },
+        },
+        guess_the_tune: {
           on: {
             BACK: "overview",
           },

--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -841,6 +841,7 @@ await this.emit("DATA_RESET", {})  // ✗ Frontend won't know to update
                                     ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
 │ Server: PluginRegistry.executePluginAction() calls plugin.executeAction │
+│   (optional second arg: initiator { userId, username } from admin socket) │
 └─────────────────────────────────────────────────────────────────────────┘
                                     │
                                     ▼

--- a/docs/adrs/0006-plugin-system-for-room-features.md
+++ b/docs/adrs/0006-plugin-system-for-room-features.md
@@ -24,7 +24,7 @@ Architecture:
 - **Augmentation hooks**: Optional `augmentPlaylistBatch()` and `augmentNowPlaying()` let plugins enrich data before it reaches clients.
 - **Actions**: Admin-triggered actions via `executeAction()` with type-safe action names.
 
-Current plugins: `playlist-democracy`, `special-words`, `absent-dj`, `queue-hygiene`.
+Current plugins: `playlist-democracy`, `special-words`, `absent-dj`, `queue-hygiene`, `guess-the-tune`.
 
 ## Consequences
 

--- a/docs/adrs/0039-plugin-element-properties-for-now-playing.md
+++ b/docs/adrs/0039-plugin-element-properties-for-now-playing.md
@@ -13,7 +13,7 @@ Introduce **`elementProps`** on `PluginAugmentationData`: a map from a small set
 
 - `obscured` — UI should redact or mask that slot.
 - `obscureBypassRoles` — advisory list of viewer roles (`admin`, `dj`, `creator`, `owner`) for which obscuring should not apply; the **web client** resolves this generically (e.g. `usePluginElementProps`) so Now Playing stays unaware of any specific plugin or its config keys.
-- `revealedBy` / `placeholder` — optional metadata for post-guess display.
+- `revealedBy` / `placeholder` — optional metadata when a slot is revealed (e.g. who guessed in chat) or obscured (placeholder text).
 
 Plugins implement `augmentNowPlaying()` and return `{ elementProps: { ... } }` under their namespaced `pluginData` entry (unchanged merge rules in `PluginRegistry`).
 

--- a/docs/adrs/0039-plugin-element-properties-for-now-playing.md
+++ b/docs/adrs/0039-plugin-element-properties-for-now-playing.md
@@ -1,0 +1,33 @@
+# 0039. Plugin element properties for Now Playing
+
+**Date:** 2026-04-20  
+**Status:** Accepted
+
+## Context
+
+Plugins need to influence how the **Now Playing** area renders (e.g. a game mode that obscures title/artist/album until players guess them) without shipping React from plugins or replacing core UI wholesale. The codebase already supported `pluginData` on `QueueItem` and `PluginAugmentationData.styles` for limited style hints; that was not enough for structured behaviors like “obscured until revealed” or role-based bypass.
+
+## Decision
+
+Introduce **`elementProps`** on `PluginAugmentationData`: a map from a small set of **element keys** (`title`, `artist`, `album`, `artwork`) to **`PluginElementProps`**, including:
+
+- `obscured` — UI should redact or mask that slot.
+- `obscureBypassRoles` — advisory list of viewer roles (`admin`, `dj`, `creator`, `owner`) for which obscuring should not apply; the **web client** resolves this generically (e.g. `usePluginElementProps`) so Now Playing stays unaware of any specific plugin or its config keys.
+- `revealedBy` / `placeholder` — optional metadata for post-guess display.
+
+Plugins implement `augmentNowPlaying()` and return `{ elementProps: { ... } }` under their namespaced `pluginData` entry (unchanged merge rules in `PluginRegistry`).
+
+The first consumer is **`@repo/plugin-guess-the-tune`**: chat fuzzy-matching, scoring, leaderboard, and `elementProps` driven obscuring.
+
+## Security / trust boundary
+
+- **Obscuring is client-side only.** Full track metadata continues to be delivered to every client in the normal `RoomMeta` / `QueueItem` payloads. A motivated user can read raw values via devtools, network capture, or a modified client.
+- **`obscureBypassRoles` is not authorization.** It is a UX hint only; it must not be used to gate sensitive server actions.
+- For this project, **that risk is accepted** for casual / party-game plugins. If a plugin required **hard secrecy**, the platform would need **server-side redaction** of broadcast payloads (or per-recipient filtering), which is explicitly **out of scope** for this ADR.
+
+## Consequences
+
+- **Extensible**: New element keys or props can be added without plugins touching React.
+- **Composable**: Multiple plugins can contribute `elementProps`; the client merges them (see `usePluginElementProps`).
+- **No real secrecy** from `elementProps` alone; room operators must understand the trust model above.
+- **Documentation**: Plugin authors should read this ADR before relying on obscuring for anything beyond UX.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -44,6 +44,7 @@ This directory contains Architectural Decision Records (ADRs) for the Listening 
 | [0036](0036-stream-health-webhook-for-live-rooms.md) | Stream Health Webhook for Live Rooms | Accepted |
 | [0037](0037-hybrid-radio-shoutcast-rtmp-bridge.md) | Hybrid Radio — Shoutcast + Optional Experimental WebRTC | Accepted |
 | [0038](0038-socket-io-client-never-give-up-reconnection.md) | Socket.IO Client — Never-Give-Up Reconnection | Accepted |
+| [0039](0039-plugin-element-properties-for-now-playing.md) | Plugin `elementProps` for Now Playing (obscure / bypass roles) | Accepted |
 
 ## Creating a New ADR
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@repo/media-source-rtmp": "*",
         "@repo/media-source-shoutcast": "*",
         "@repo/plugin-absent-dj": "*",
+        "@repo/plugin-guess-the-tune": "*",
         "@repo/plugin-playlist-democracy": "*",
         "@repo/plugin-queue-hygiene": "*",
         "@repo/plugin-special-words": "*",
@@ -2566,6 +2567,10 @@
     },
     "node_modules/@repo/plugin-base": {
       "resolved": "packages/plugin-base",
+      "link": true
+    },
+    "node_modules/@repo/plugin-guess-the-tune": {
+      "resolved": "packages/plugin-guess-the-tune",
       "link": true
     },
     "node_modules/@repo/plugin-playlist-democracy": {
@@ -7597,6 +7602,18 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/gemoji": {
@@ -15049,6 +15066,34 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "packages/plugin-guess-the-tune": {
+      "name": "@repo/plugin-guess-the-tune",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@repo/plugin-base": "*",
+        "@repo/types": "*",
+        "@repo/utils": "*",
+        "fuse.js": "^7.1.0"
+      },
+      "devDependencies": {
+        "@repo/eslint-config": "*",
+        "@repo/typescript-config": "*",
+        "vitest": "^4.0.13"
+      },
+      "peerDependencies": {
+        "zod": "^4.1.13"
+      }
+    },
+    "packages/plugin-guess-the-tune/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "packages/plugin-playlist-democracy": {
       "name": "@repo/plugin-playlist-democracy",
       "version": "1.0.0",
@@ -16841,6 +16886,26 @@
       "dependencies": {
         "zod": {
           "version": "4.1.13"
+        }
+      }
+    },
+    "@repo/plugin-guess-the-tune": {
+      "version": "file:packages/plugin-guess-the-tune",
+      "requires": {
+        "@repo/eslint-config": "*",
+        "@repo/plugin-base": "*",
+        "@repo/types": "*",
+        "@repo/typescript-config": "*",
+        "@repo/utils": "*",
+        "fuse.js": "^7.1.0",
+        "vitest": "^4.0.13"
+      },
+      "dependencies": {
+        "zod": {
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+          "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+          "peer": true
         }
       }
     },
@@ -18794,6 +18859,7 @@
         "@repo/media-source-rtmp": "*",
         "@repo/media-source-shoutcast": "*",
         "@repo/plugin-absent-dj": "*",
+        "@repo/plugin-guess-the-tune": "*",
         "@repo/plugin-playlist-democracy": "*",
         "@repo/plugin-queue-hygiene": "*",
         "@repo/plugin-special-words": "*",
@@ -20447,6 +20513,11 @@
     },
     "function-bind": {
       "version": "1.1.2"
+    },
+    "fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w=="
     },
     "gemoji": {
       "version": "7.1.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dev": "turbo run dev",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "turbo run lint",
-    "test": "turbo run test"
+    "test": "turbo run test --continue=always"
   },
   "author": "",
   "license": "ISC",

--- a/packages/plugin-base/index.ts
+++ b/packages/plugin-base/index.ts
@@ -1,6 +1,7 @@
 import type { z } from "zod"
 import {
   Plugin,
+  PluginActionInitiator,
   PluginContext,
   PluginAugmentationData,
   PluginLifecycleEvents,
@@ -647,11 +648,12 @@ export abstract class BasePlugin<TConfig = any> implements Plugin {
    * Override this method to handle custom actions defined in getConfigSchema().
    *
    * @param action - The action identifier from PluginActionElement
+   * @param initiator - When invoked from the admin room socket, the acting user (server-derived; not from the client payload)
    * @returns Result with success status and optional message
    *
    * @example
    * ```typescript
-   * async executeAction(action: string): Promise<{ success: boolean; message?: string }> {
+   * async executeAction(action: string, initiator?: PluginActionInitiator): Promise<{ success: boolean; message?: string }> {
    *   if (action === 'resetLeaderboards') {
    *     await this.clearAllLeaderboards()
    *     return { success: true, message: 'Leaderboards reset successfully' }
@@ -660,7 +662,10 @@ export abstract class BasePlugin<TConfig = any> implements Plugin {
    * }
    * ```
    */
-  async executeAction(action: string): Promise<{ success: boolean; message?: string }> {
+  async executeAction(
+    action: string,
+    _initiator?: PluginActionInitiator,
+  ): Promise<{ success: boolean; message?: string }> {
     return { success: false, message: `Unknown action: ${action}` }
   }
 }

--- a/packages/plugin-base/package.json
+++ b/packages/plugin-base/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "lint": "prettier --write . && eslint . --fix",
     "format": "prettier --write .",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "author": "",
   "license": "ISC",

--- a/packages/plugin-guess-the-tune/eslint.config.js
+++ b/packages/plugin-guess-the-tune/eslint.config.js
@@ -1,0 +1,3 @@
+import serverConfig from "@repo/eslint-config/server"
+
+export default [...serverConfig]

--- a/packages/plugin-guess-the-tune/index.test.ts
+++ b/packages/plugin-guess-the-tune/index.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest"
+import { messageMatchesTarget } from "./matching"
+
+describe("messageMatchesTarget", () => {
+  it("matches exact substring", () => {
+    expect(messageMatchesTarget("I love Pink Floyd", "Pink Floyd", 0.5)).toBe(true)
+  })
+
+  it("matches fuzzy when each target word appears in the message", () => {
+    expect(messageMatchesTarget("pink floyed?", "Pink Floyd", 0.55)).toBe(true)
+  })
+
+  it("rejects unrelated text", () => {
+    expect(messageMatchesTarget("hello world", "Metallica", 0.35)).toBe(false)
+  })
+
+  it("does not match a single word from a long title", () => {
+    expect(
+      messageMatchesTarget("how", "How Music Makes You Feel Better", 0.45),
+    ).toBe(false)
+  })
+
+  it("matches when every title word is represented (with per-word typos)", () => {
+    expect(
+      messageMatchesTarget(
+        "How music makes u feel better",
+        "How Music Makes You Feel Better",
+        0.55,
+      ),
+    ).toBe(true)
+  })
+})

--- a/packages/plugin-guess-the-tune/index.test.ts
+++ b/packages/plugin-guess-the-tune/index.test.ts
@@ -31,6 +31,15 @@ describe("messageMatchesTarget", () => {
       ),
     ).toBe(true)
   })
+
+  it("does not match a tiny fragment against a one-word title", () => {
+    expect(messageMatchesTarget("ch", "charlie", 0.55)).toBe(false)
+  })
+
+  it("matches a one-word title when the guess is long enough to be a real attempt", () => {
+    expect(messageMatchesTarget("charlie", "charlie", 0.55)).toBe(true)
+    expect(messageMatchesTarget("charl", "charlie", 0.55)).toBe(true)
+  })
 })
 
 describe("propsInPlay", () => {

--- a/packages/plugin-guess-the-tune/index.test.ts
+++ b/packages/plugin-guess-the-tune/index.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest"
 import { messageMatchesTarget } from "./matching"
+import { propsInPlay } from "./index"
+import { defaultGuessTheTuneConfig } from "./types"
 
 describe("messageMatchesTarget", () => {
   it("matches exact substring", () => {
@@ -28,5 +30,27 @@ describe("messageMatchesTarget", () => {
         0.55,
       ),
     ).toBe(true)
+  })
+})
+
+describe("propsInPlay", () => {
+  const base = { ...defaultGuessTheTuneConfig }
+
+  it("returns only fields that are enabled and non-empty", () => {
+    expect(
+      propsInPlay(
+        { ...base, matchTitle: true, matchArtist: false, matchAlbum: true },
+        { title: "  x  ", artist: "A", album: "" },
+      ),
+    ).toEqual(["title"])
+  })
+
+  it("returns title artist album in stable order when all apply", () => {
+    expect(
+      propsInPlay(
+        { ...base, matchTitle: true, matchArtist: true, matchAlbum: true },
+        { title: "T", artist: "A", album: "L" },
+      ),
+    ).toEqual(["title", "artist", "album"])
   })
 })

--- a/packages/plugin-guess-the-tune/index.ts
+++ b/packages/plugin-guess-the-tune/index.ts
@@ -197,14 +197,12 @@ export class GuessTheTunePlugin extends BasePlugin<GuessTheTuneConfig> {
       revealedAll[field] = JSON.stringify(revealedBy)
 
       const elapsed = Date.now() - startedAt
-      const mult =
-        elapsed <= config.speedMultiplierWindowSec * 1000 ? config.speedMultiplier : 1
+      const mult = elapsed <= config.speedMultiplierWindowSec * 1000 ? config.speedMultiplier : 1
       const points = Math.floor(basePoints[prop] * mult)
 
       await this.context.storage.zincrby(USER_SCORES_KEY, points, message.user.userId)
 
-      const multiplierSuffix =
-        mult > 1 ? ` (${mult}× speed bonus)` : ""
+      const multiplierSuffix = mult > 1 ? ` (${mult}× speed bonus)` : ""
 
       const body = interpolateTemplate(config.messageTemplate ?? "", {
         username: message.user.username ?? message.user.userId,
@@ -229,7 +227,7 @@ export class GuessTheTunePlugin extends BasePlugin<GuessTheTuneConfig> {
       if (config.soundEffectOnMatch) {
         await this.context.api.queueSoundEffect({
           url: config.soundEffectOnMatchUrl ?? "",
-          volume: 0.5,
+          volume: 0.3,
         })
       }
 
@@ -531,9 +529,7 @@ export class GuessTheTunePlugin extends BasePlugin<GuessTheTuneConfig> {
   }
 }
 
-export function createGuessTheTunePlugin(
-  configOverrides?: Partial<GuessTheTuneConfig>,
-): Plugin {
+export function createGuessTheTunePlugin(configOverrides?: Partial<GuessTheTuneConfig>): Plugin {
   return new GuessTheTunePlugin(configOverrides)
 }
 

--- a/packages/plugin-guess-the-tune/index.ts
+++ b/packages/plugin-guess-the-tune/index.ts
@@ -1,0 +1,349 @@
+import type {
+  Plugin,
+  PluginContext,
+  PluginConfigSchema,
+  PluginComponentSchema,
+  SystemEventPayload,
+  ChatMessage,
+  PluginAugmentationData,
+  PluginElementKey,
+  PluginElementProps,
+  PluginObscureBypassRole,
+  PluginTextElementKey,
+  QueueItem,
+  RoomExportData,
+  PluginExportAugmentation,
+} from "@repo/types"
+import { queueItemStableKey } from "@repo/types"
+import { BasePlugin } from "@repo/plugin-base"
+import { interpolateTemplate } from "@repo/utils"
+import packageJson from "./package.json"
+import {
+  guessTheTuneConfigSchema,
+  defaultGuessTheTuneConfig,
+  type GuessTheTuneConfig,
+  type GuessProperty,
+} from "./types"
+import { getComponentSchema, getConfigSchema } from "./schema"
+import { messageMatchesTarget } from "./matching"
+
+export type { GuessTheTuneConfig } from "./types"
+export { guessTheTuneConfigSchema, defaultGuessTheTuneConfig } from "./types"
+
+const USER_SCORES_KEY = "user-scores"
+
+function roundKey(stable: string): string {
+  return `round:${stable}`
+}
+
+const TEXT_KEYS = ["title", "artist", "album"] as const satisfies readonly PluginTextElementKey[]
+
+export interface GuessTheTuneComponentState extends Record<string, unknown> {
+  usersLeaderboard: { score: number; value: string; username: string }[]
+}
+
+export interface GuessTheTuneEvents {
+  PROPERTY_REVEALED: {
+    property: GuessProperty
+    userId: string
+    username?: string
+    points: number
+    multiplier: number
+    usersLeaderboard: { score: number; value: string; username: string }[]
+  }
+  LEADERBOARD_RESET: {
+    usersLeaderboard: { score: number; value: string; username: string }[]
+  }
+}
+
+function trackStrings(track: QueueItem["track"] | null | undefined): Record<GuessProperty, string> {
+  if (!track) return { title: "", artist: "", album: "" }
+  const title = track.title ?? ""
+  const artist = track.artists?.map((a) => a.title).join(", ") ?? ""
+  const album = track.album?.title ?? ""
+  return { title, artist, album }
+}
+
+function propertyLabel(p: GuessProperty): string {
+  switch (p) {
+    case "title":
+      return "track title"
+    case "artist":
+      return "artist name"
+    case "album":
+      return "album title"
+  }
+}
+
+function capitalize(s: string): string {
+  return s.length ? s[0]!.toUpperCase() + s.slice(1) : s
+}
+
+export class GuessTheTunePlugin extends BasePlugin<GuessTheTuneConfig> {
+  name = "guess-the-tune"
+  version = packageJson.version
+  description =
+    "Game mode: obscure now playing metadata, fuzzy-match chat guesses, and score a leaderboard."
+
+  /** Cast avoids duplicate zod installs resolving to different `z` module instances under npm workspaces. */
+  static readonly configSchema = guessTheTuneConfigSchema as any
+  static readonly defaultConfig = defaultGuessTheTuneConfig
+  static readonly defaultConfig = defaultGuessTheTuneConfig
+
+  getComponentSchema(): PluginComponentSchema {
+    return getComponentSchema()
+  }
+
+  getConfigSchema(): PluginConfigSchema {
+    return getConfigSchema()
+  }
+
+  async getComponentState(): Promise<GuessTheTuneComponentState> {
+    if (!this.context) return { usersLeaderboard: [] }
+
+    const raw = await this.context.storage.zrangeWithScores(USER_SCORES_KEY, 0, -1)
+    const sorted = [...raw].sort((a, b) => b.score - a.score)
+    const userIds = sorted.map((e) => e.value)
+    const users = await this.context.api.getUsersByIds(userIds)
+    const userMap = new Map(users.map((u) => [u.userId, u.username]))
+
+    const usersLeaderboard = sorted.map((entry) => ({
+      ...entry,
+      username: userMap.get(entry.value) ?? entry.value,
+    }))
+
+    return { usersLeaderboard }
+  }
+
+  async register(context: PluginContext): Promise<void> {
+    await super.register(context)
+    this.on("TRACK_CHANGED", this.onTrackChanged.bind(this))
+    this.on("MESSAGE_RECEIVED", this.onMessageReceived.bind(this))
+  }
+
+  private async onTrackChanged(data: SystemEventPayload<"TRACK_CHANGED">): Promise<void> {
+    const config = await this.getConfig()
+    if (!config?.enabled || !this.context) return
+
+    const stable = queueItemStableKey(data.track)
+    const rk = roundKey(stable)
+    await this.context.storage.del(rk)
+    await this.context.storage.hset(rk, "startedAt", String(Date.now()))
+
+    const np = await this.context.api.getNowPlaying(this.context.roomId)
+    if (np) {
+      await this.context.api.updatePlaylistTrack(this.context.roomId, np)
+    }
+  }
+
+  private async onMessageReceived(data: SystemEventPayload<"MESSAGE_RECEIVED">): Promise<void> {
+    const config = await this.getConfig()
+    if (!config?.enabled || !this.context) return
+
+    const { message } = data
+    if (this.isSystemMessage(message)) return
+
+    const np = await this.context.api.getNowPlaying(this.context.roomId)
+    if (!np?.track) return
+
+    const stable = queueItemStableKey(np)
+    const rk = roundKey(stable)
+    const startedAtStr = await this.context.storage.hget(rk, "startedAt")
+    if (!startedAtStr) return
+
+    const startedAt = Number(startedAtStr)
+    const targets = trackStrings(np.track)
+    const revealedAll: Record<string, string> = { ...(await this.context.storage.hgetall(rk)) }
+
+    const propsToTry: GuessProperty[] = []
+    if (config.matchTitle && targets.title.trim()) propsToTry.push("title")
+    if (config.matchArtist && targets.artist.trim()) propsToTry.push("artist")
+    if (config.matchAlbum && targets.album.trim()) propsToTry.push("album")
+
+    const basePoints: Record<GuessProperty, number> = {
+      title: config.pointsTitle,
+      artist: config.pointsArtist,
+      album: config.pointsAlbum,
+    }
+
+    let needsMetaRefresh = false
+
+    for (const prop of propsToTry) {
+      const field = `revealed:${prop}`
+      if (revealedAll[field]) continue
+
+      const target = targets[prop]
+      if (!messageMatchesTarget(message.content, target, config.fuzzyThreshold)) continue
+
+      const revealJson = JSON.stringify({
+        userId: message.user.userId,
+        username: message.user.username ?? "",
+        at: Date.now(),
+      })
+
+      const didSet = await this.context.storage.hsetnx(rk, field, revealJson)
+      if (!didSet) continue
+      revealedAll[field] = revealJson
+
+      const elapsed = Date.now() - startedAt
+      const mult =
+        elapsed <= config.speedMultiplierWindowSec * 1000 ? config.speedMultiplier : 1
+      const points = Math.floor(basePoints[prop] * mult)
+
+      await this.context.storage.zincrby(USER_SCORES_KEY, points, message.user.userId)
+
+      const multiplierSuffix =
+        mult > 1 ? ` (${mult}× speed bonus)` : ""
+
+      const body = interpolateTemplate(config.messageTemplate ?? "", {
+        username: message.user.username ?? message.user.userId,
+        propertyLabel: propertyLabel(prop),
+        points: String(points),
+        multiplierSuffix,
+      })
+
+      await this.context.api.sendSystemMessage(this.context.roomId, body)
+
+      const state = await this.getComponentState()
+
+      await this.emit<GuessTheTuneEvents["PROPERTY_REVEALED"]>("PROPERTY_REVEALED", {
+        property: prop,
+        userId: message.user.userId,
+        username: message.user.username ?? undefined,
+        points,
+        multiplier: mult,
+        usersLeaderboard: state.usersLeaderboard,
+      })
+
+      if (config.soundEffectOnMatch) {
+        await this.context.api.queueSoundEffect({
+          url: config.soundEffectOnMatchUrl ?? "",
+          volume: 0.5,
+        })
+      }
+
+      needsMetaRefresh = true
+    }
+
+    if (needsMetaRefresh) {
+      const fresh = await this.context.api.getNowPlaying(this.context.roomId)
+      if (fresh) {
+        await this.context.api.updatePlaylistTrack(this.context.roomId, fresh)
+      }
+    }
+  }
+
+  async augmentNowPlaying(item: QueueItem): Promise<PluginAugmentationData> {
+    if (!this.context) return {}
+
+    const config = await this.getConfig()
+    if (!config?.enabled) return {}
+
+    if (!config.matchTitle && !config.matchArtist && !config.matchAlbum) {
+      return {}
+    }
+
+    const stable = queueItemStableKey(item)
+    const rk = roundKey(stable)
+    const revealed = await this.context.storage.hgetall(rk)
+
+    const bypassRoles: PluginObscureBypassRole[] = config.showNowPlayingToAdmins ? ["admin"] : []
+
+    const elementProps: Partial<Record<PluginElementKey, PluginElementProps>> = {}
+
+    for (const key of TEXT_KEYS) {
+      const matchKey = `match${capitalize(key)}` as keyof GuessTheTuneConfig
+      if (!config[matchKey]) continue
+
+      const rev = revealed[`revealed:${key}`]
+      if (rev) {
+        try {
+          const revealedBy = JSON.parse(rev) as PluginElementProps["revealedBy"]
+          elementProps[key] = { obscured: false, revealedBy }
+        } catch {
+          elementProps[key] = { obscured: false }
+        }
+      } else {
+        elementProps[key] = {
+          obscured: true,
+          placeholder: "???",
+          obscureBypassRoles: bypassRoles,
+        }
+      }
+    }
+
+    // Artwork often shows artist/album text — keep placeholder until both are revealed (when enabled).
+    const artistRevealed = Boolean(revealed["revealed:artist"])
+    const albumRevealed = Boolean(revealed["revealed:album"])
+    const artworkObscured =
+      (config.matchArtist && !artistRevealed) || (config.matchAlbum && !albumRevealed)
+
+    elementProps.artwork = {
+      obscured: artworkObscured,
+      obscureBypassRoles: bypassRoles,
+    }
+
+    return { elementProps }
+  }
+
+  async augmentRoomExport(exportData: RoomExportData): Promise<PluginExportAugmentation> {
+    const state = await this.getComponentState()
+    const allUsers = [...(exportData.userHistory || []), ...exportData.users]
+    const userMap = new Map(allUsers.map((u) => [u.userId, u.username]))
+
+    const hydrated = state.usersLeaderboard.map((item, index) => ({
+      rank: index + 1,
+      userId: item.value,
+      username: userMap.get(item.value) ?? item.value,
+      score: item.score,
+    }))
+
+    return {
+      data: { usersLeaderboard: hydrated },
+      markdownSections: [
+        `## Guess the Tune Leaderboard\n\n${hydrated.map((r) => `${r.rank}. ${r.username}: ${r.score} points`).join("\n")}\n`,
+      ],
+    }
+  }
+
+  async executeAction(action: string): Promise<{ success: boolean; message?: string }> {
+    if (action === "resetLeaderboard") {
+      return this.resetLeaderboard()
+    }
+    return { success: false, message: `Unknown action: ${action}` }
+  }
+
+  private async resetLeaderboard(): Promise<{ success: boolean; message?: string }> {
+    if (!this.context) {
+      return { success: false, message: "Plugin not initialized" }
+    }
+
+    try {
+      const entries = await this.context.storage.zrangeWithScores(USER_SCORES_KEY, 0, -1)
+      for (const e of entries) {
+        await this.context.storage.zrem(USER_SCORES_KEY, e.value)
+      }
+
+      await this.emit<GuessTheTuneEvents["LEADERBOARD_RESET"]>("LEADERBOARD_RESET", {
+        usersLeaderboard: [],
+      })
+
+      return { success: true, message: "Leaderboard reset" }
+    } catch (e) {
+      console.error(`[${this.name}] resetLeaderboard`, e)
+      return { success: false, message: String(e) }
+    }
+  }
+
+  private isSystemMessage(message: ChatMessage): boolean {
+    return message.user.userId === "system"
+  }
+}
+
+export function createGuessTheTunePlugin(
+  configOverrides?: Partial<GuessTheTuneConfig>,
+): Plugin {
+  return new GuessTheTunePlugin(configOverrides)
+}
+
+export default createGuessTheTunePlugin

--- a/packages/plugin-guess-the-tune/index.ts
+++ b/packages/plugin-guess-the-tune/index.ts
@@ -1,5 +1,6 @@
 import type {
   Plugin,
+  PluginActionInitiator,
   PluginContext,
   PluginConfigSchema,
   PluginComponentSchema,
@@ -79,6 +80,20 @@ function capitalize(s: string): string {
   return s.length ? s[0]!.toUpperCase() + s.slice(1) : s
 }
 
+/** Which guess fields apply for the current config and track strings (used by chat matching and admin reveal). */
+export function propsInPlay(
+  config: GuessTheTuneConfig,
+  targets: Record<GuessProperty, string>,
+): GuessProperty[] {
+  const props: GuessProperty[] = []
+  if (config.matchTitle && targets.title.trim()) props.push("title")
+  if (config.matchArtist && targets.artist.trim()) props.push("artist")
+  if (config.matchAlbum && targets.album.trim()) props.push("album")
+  return props
+}
+
+type RevealByPayload = NonNullable<PluginElementProps["revealedBy"]>
+
 export class GuessTheTunePlugin extends BasePlugin<GuessTheTuneConfig> {
   name = "guess-the-tune"
   version = packageJson.version
@@ -87,7 +102,6 @@ export class GuessTheTunePlugin extends BasePlugin<GuessTheTuneConfig> {
 
   /** Cast avoids duplicate zod installs resolving to different `z` module instances under npm workspaces. */
   static readonly configSchema = guessTheTuneConfigSchema as any
-  static readonly defaultConfig = defaultGuessTheTuneConfig
   static readonly defaultConfig = defaultGuessTheTuneConfig
 
   getComponentSchema(): PluginComponentSchema {
@@ -155,10 +169,7 @@ export class GuessTheTunePlugin extends BasePlugin<GuessTheTuneConfig> {
     const targets = trackStrings(np.track)
     const revealedAll: Record<string, string> = { ...(await this.context.storage.hgetall(rk)) }
 
-    const propsToTry: GuessProperty[] = []
-    if (config.matchTitle && targets.title.trim()) propsToTry.push("title")
-    if (config.matchArtist && targets.artist.trim()) propsToTry.push("artist")
-    if (config.matchAlbum && targets.album.trim()) propsToTry.push("album")
+    const propsToTry = propsInPlay(config, targets)
 
     const basePoints: Record<GuessProperty, number> = {
       title: config.pointsTitle,
@@ -175,15 +186,15 @@ export class GuessTheTunePlugin extends BasePlugin<GuessTheTuneConfig> {
       const target = targets[prop]
       if (!messageMatchesTarget(message.content, target, config.fuzzyThreshold)) continue
 
-      const revealJson = JSON.stringify({
+      const revealedBy: RevealByPayload = {
         userId: message.user.userId,
         username: message.user.username ?? "",
         at: Date.now(),
-      })
+      }
 
-      const didSet = await this.context.storage.hsetnx(rk, field, revealJson)
+      const didSet = await this.revealRoundProperty(rk, prop, revealedBy)
       if (!didSet) continue
-      revealedAll[field] = revealJson
+      revealedAll[field] = JSON.stringify(revealedBy)
 
       const elapsed = Date.now() - startedAt
       const mult =
@@ -259,7 +270,11 @@ export class GuessTheTunePlugin extends BasePlugin<GuessTheTuneConfig> {
       if (rev) {
         try {
           const revealedBy = JSON.parse(rev) as PluginElementProps["revealedBy"]
-          elementProps[key] = { obscured: false, revealedBy }
+          if (revealedBy?.userId != null) {
+            elementProps[key] = { obscured: false, revealedBy }
+          } else {
+            elementProps[key] = { obscured: false }
+          }
         } catch {
           elementProps[key] = { obscured: false }
         }
@@ -306,11 +321,187 @@ export class GuessTheTunePlugin extends BasePlugin<GuessTheTuneConfig> {
     }
   }
 
-  async executeAction(action: string): Promise<{ success: boolean; message?: string }> {
+  async executeAction(
+    action: string,
+    initiator?: PluginActionInitiator,
+  ): Promise<{ success: boolean; message?: string }> {
     if (action === "resetLeaderboard") {
       return this.resetLeaderboard()
     }
+    if (action === "revealTitle") {
+      return this.adminRevealProperty("title", initiator)
+    }
+    if (action === "revealArtist") {
+      return this.adminRevealProperty("artist", initiator)
+    }
+    if (action === "revealAlbum") {
+      return this.adminRevealProperty("album", initiator)
+    }
+    if (action === "revealAll") {
+      return this.adminRevealAll(initiator)
+    }
     return { success: false, message: `Unknown action: ${action}` }
+  }
+
+  /**
+   * Atomically set `revealed:{prop}` when not already set. Returns whether this call stored a new value.
+   */
+  private async revealRoundProperty(
+    rk: string,
+    prop: GuessProperty,
+    revealedBy: RevealByPayload,
+  ): Promise<boolean> {
+    if (!this.context) return false
+    const field = `revealed:${prop}`
+    return this.context.storage.hsetnx(rk, field, JSON.stringify(revealedBy))
+  }
+
+  private resolveAdminRevealLabel(initiator?: PluginActionInitiator): string {
+    const username = initiator?.username?.trim()
+    if (username) return username
+    const userId = initiator?.userId?.trim()
+    if (userId && userId !== "system") return userId
+    return "A room admin"
+  }
+
+  private buildAdminRevealedBy(initiator?: PluginActionInitiator): RevealByPayload {
+    const userId = initiator?.userId?.trim() || "system"
+    const label = this.resolveAdminRevealLabel(initiator)
+    const username = initiator?.username?.trim() || label
+    return {
+      userId,
+      username,
+      at: Date.now(),
+      source: "admin",
+    }
+  }
+
+  private async adminRevealProperty(
+    prop: GuessProperty,
+    initiator?: PluginActionInitiator,
+  ): Promise<{ success: boolean; message?: string }> {
+    if (!this.context) {
+      return { success: false, message: "Plugin not initialized" }
+    }
+
+    const config = await this.getConfig()
+    if (!config?.enabled) {
+      return { success: false, message: "Guess the Tune is disabled." }
+    }
+
+    const np = await this.context.api.getNowPlaying(this.context.roomId)
+    if (!np?.track) {
+      return { success: false, message: "Nothing is playing." }
+    }
+
+    const stable = queueItemStableKey(np)
+    const rk = roundKey(stable)
+    const startedAtStr = await this.context.storage.hget(rk, "startedAt")
+    if (!startedAtStr) {
+      return { success: false, message: "No active round for the current track." }
+    }
+
+    const targets = trackStrings(np.track)
+    const inPlay = propsInPlay(config, targets)
+    if (!inPlay.includes(prop)) {
+      return {
+        success: false,
+        message: `The ${propertyLabel(prop)} is not obscured for this track.`,
+      }
+    }
+
+    const field = `revealed:${prop}`
+    if (await this.context.storage.hget(rk, field)) {
+      return { success: true, message: `${capitalize(propertyLabel(prop))} is already revealed.` }
+    }
+
+    const label = this.resolveAdminRevealLabel(initiator)
+    const revealedBy = this.buildAdminRevealedBy(initiator)
+    const didSet = await this.revealRoundProperty(rk, prop, revealedBy)
+    if (!didSet) {
+      return { success: true, message: `${capitalize(propertyLabel(prop))} is already revealed.` }
+    }
+
+    await this.context.api.sendSystemMessage(
+      this.context.roomId,
+      `${label} revealed the ${propertyLabel(prop)} for everyone.`,
+    )
+
+    const fresh = await this.context.api.getNowPlaying(this.context.roomId)
+    if (fresh) {
+      await this.context.api.updatePlaylistTrack(this.context.roomId, fresh)
+    }
+
+    return { success: true, message: `${capitalize(propertyLabel(prop))} revealed for everyone.` }
+  }
+
+  private async adminRevealAll(
+    initiator?: PluginActionInitiator,
+  ): Promise<{ success: boolean; message?: string }> {
+    if (!this.context) {
+      return { success: false, message: "Plugin not initialized" }
+    }
+
+    const config = await this.getConfig()
+    if (!config?.enabled) {
+      return { success: false, message: "Guess the Tune is disabled." }
+    }
+
+    const np = await this.context.api.getNowPlaying(this.context.roomId)
+    if (!np?.track) {
+      return { success: false, message: "Nothing is playing." }
+    }
+
+    const stable = queueItemStableKey(np)
+    const rk = roundKey(stable)
+    const startedAtStr = await this.context.storage.hget(rk, "startedAt")
+    if (!startedAtStr) {
+      return { success: false, message: "No active round for the current track." }
+    }
+
+    const targets = trackStrings(np.track)
+    const order: GuessProperty[] = ["title", "artist", "album"]
+    const inPlay = new Set(propsInPlay(config, targets))
+    const toReveal = order.filter((p) => inPlay.has(p))
+
+    if (toReveal.length === 0) {
+      return {
+        success: false,
+        message: "No metadata is configured to be obscured for this track.",
+      }
+    }
+
+    const label = this.resolveAdminRevealLabel(initiator)
+    let anyNew = false
+
+    for (const prop of toReveal) {
+      const field = `revealed:${prop}`
+      if (await this.context.storage.hget(rk, field)) continue
+
+      const revealedBy = this.buildAdminRevealedBy(initiator)
+      const didSet = await this.revealRoundProperty(rk, prop, {
+        ...revealedBy,
+        at: Date.now(),
+      })
+      if (!didSet) continue
+
+      anyNew = true
+      await this.context.api.sendSystemMessage(
+        this.context.roomId,
+        `${label} revealed the ${propertyLabel(prop)} for everyone.`,
+      )
+    }
+
+    if (!anyNew) {
+      return { success: true, message: "All obscured fields were already revealed." }
+    }
+
+    const fresh = await this.context.api.getNowPlaying(this.context.roomId)
+    if (fresh) {
+      await this.context.api.updatePlaylistTrack(this.context.roomId, fresh)
+    }
+
+    return { success: true, message: "Revealed all obscured fields for everyone." }
   }
 
   private async resetLeaderboard(): Promise<{ success: boolean; message?: string }> {

--- a/packages/plugin-guess-the-tune/matching.ts
+++ b/packages/plugin-guess-the-tune/matching.ts
@@ -1,0 +1,97 @@
+import Fuse from "fuse.js"
+
+const norm = (s: string) =>
+  s
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+
+/** Target tokens shorter than this are not required individually (e.g. "a", "i"). */
+const MIN_TARGET_WORD_LEN = 2
+
+/**
+ * Tokenize normalized text into words for matching.
+ */
+function words(s: string): string[] {
+  return s.split(/\s+/).filter((w) => w.length > 0)
+}
+
+/**
+ * Build message-side candidates: each word plus adjacent bigrams (so "feel better"
+ * can still match two target words when the message has that phrase).
+ */
+function messageMatchCandidates(messageNorm: string): string[] {
+  const ws = words(messageNorm)
+  const out = new Set<string>()
+  for (const w of ws) {
+    out.add(w)
+  }
+  for (let i = 0; i < ws.length - 1; i++) {
+    const bi = `${ws[i]} ${ws[i + 1]}`.trim()
+    if (bi.length >= 1) out.add(bi)
+  }
+  return Array.from(out)
+}
+
+/**
+ * True if `candidate` is a fuzzy match for the single word `targetWord` (Fuse threshold).
+ * Single-character candidates are only considered against longer targets (e.g. "u" → "you").
+ */
+function tokenMatchesTargetWord(
+  candidate: string,
+  targetWord: string,
+  fuzzyThreshold: number,
+): boolean {
+  if (!candidate.length || !targetWord.length) return false
+  if (candidate.length === 1 && targetWord.length < 3) return false
+
+  const fuse = new Fuse([{ text: targetWord }], {
+    keys: ["text"],
+    threshold: fuzzyThreshold,
+    ignoreLocation: true,
+    // Allow single-character queries (e.g. "u" vs "you"); stricter logic is "all words" above.
+    minMatchCharLength: 1,
+  })
+  return fuse.search(candidate).length > 0
+}
+
+/**
+ * Returns true if `message` fuzzy-matches `target` (case-insensitive).
+ *
+ * **All significant words** in `target` must have at least one fuzzy match among
+ * message words (or adjacent two-word phrases). This prevents a single token like
+ * "how" from matching the full title "How Music Makes You Feel Better".
+ *
+ * Accepts typos per word, e.g. "How music makes u feel better" vs the full title.
+ */
+export function messageMatchesTarget(
+  message: string,
+  target: string,
+  fuzzyThreshold: number,
+): boolean {
+  const t = norm(target)
+  const m = norm(message)
+  if (!t.length || !m.length) return false
+
+  // Full normalized title appears in the message
+  if (m.includes(t)) return true
+
+  const targetTokens = words(t).filter((w) => w.length >= MIN_TARGET_WORD_LEN)
+  if (targetTokens.length === 0) {
+    // Very short title: fall back to single-token fuzzy against whole message
+    const single = words(t)[0] ?? t
+    if (single.length < MIN_TARGET_WORD_LEN) return false
+    const candidates = messageMatchCandidates(m)
+    return candidates.some((c) => tokenMatchesTargetWord(c, single, fuzzyThreshold))
+  }
+
+  const candidates = messageMatchCandidates(m)
+
+  for (const targetWord of targetTokens) {
+    const matched = candidates.some((c) => tokenMatchesTargetWord(c, targetWord, fuzzyThreshold))
+    if (!matched) return false
+  }
+
+  return true
+}

--- a/packages/plugin-guess-the-tune/matching.ts
+++ b/packages/plugin-guess-the-tune/matching.ts
@@ -35,16 +35,33 @@ function messageMatchCandidates(messageNorm: string): string[] {
 }
 
 /**
+ * For a one-word target (e.g. title "charlie"), reject guesses that are far shorter than
+ * the word, so "ch" does not match "charlie". Multi-word titles still use per-word fuzzy
+ * matching (e.g. "u" → "you" for a short target word in a longer title).
+ */
+function minCandidateLengthForSingleWordTarget(targetWord: string): number {
+  if (targetWord.length <= 2) return 1
+  if (targetWord.length === 3) return 2
+  return Math.max(3, Math.ceil(targetWord.length * 0.5))
+}
+
+/**
  * True if `candidate` is a fuzzy match for the single word `targetWord` (Fuse threshold).
  * Single-character candidates are only considered against longer targets (e.g. "u" → "you").
+ * When `treatAsSingleWordTitle` is true, `candidate` must be long enough (see
+ * `minCandidateLengthForSingleWordTarget`); this blocks tiny fragments like "ch" on "charlie".
  */
 function tokenMatchesTargetWord(
   candidate: string,
   targetWord: string,
   fuzzyThreshold: number,
+  treatAsSingleWordTitle: boolean,
 ): boolean {
   if (!candidate.length || !targetWord.length) return false
   if (candidate.length === 1 && targetWord.length < 3) return false
+  if (treatAsSingleWordTitle && candidate.length < minCandidateLengthForSingleWordTarget(targetWord)) {
+    return false
+  }
 
   const fuse = new Fuse([{ text: targetWord }], {
     keys: ["text"],
@@ -83,13 +100,16 @@ export function messageMatchesTarget(
     const single = words(t)[0] ?? t
     if (single.length < MIN_TARGET_WORD_LEN) return false
     const candidates = messageMatchCandidates(m)
-    return candidates.some((c) => tokenMatchesTargetWord(c, single, fuzzyThreshold))
+    return candidates.some((c) => tokenMatchesTargetWord(c, single, fuzzyThreshold, true))
   }
 
   const candidates = messageMatchCandidates(m)
+  const singleSignificantToken = targetTokens.length === 1
 
   for (const targetWord of targetTokens) {
-    const matched = candidates.some((c) => tokenMatchesTargetWord(c, targetWord, fuzzyThreshold))
+    const matched = candidates.some((c) =>
+      tokenMatchesTargetWord(c, targetWord, fuzzyThreshold, singleSignificantToken),
+    )
     if (!matched) return false
   }
 

--- a/packages/plugin-guess-the-tune/package.json
+++ b/packages/plugin-guess-the-tune/package.json
@@ -9,7 +9,7 @@
     "./types": "./types.ts"
   },
   "scripts": {
-    "test": "vitest run",
+    "test": "vitest run --reporter=dot",
     "test:watch": "vitest",
     "lint": "prettier --write . && eslint . --fix",
     "format": "prettier --write ."

--- a/packages/plugin-guess-the-tune/package.json
+++ b/packages/plugin-guess-the-tune/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@repo/plugin-guess-the-tune",
+  "version": "1.0.0",
+  "description": "Guess the Tune — obscure now playing, fuzzy chat matches, leaderboard",
+  "main": "index.ts",
+  "types": "index.ts",
+  "exports": {
+    ".": "./index.ts",
+    "./types": "./types.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "prettier --write . && eslint . --fix",
+    "format": "prettier --write ."
+  },
+  "license": "ISC",
+  "devDependencies": {
+    "@repo/eslint-config": "*",
+    "@repo/typescript-config": "*",
+    "vitest": "^4.0.13"
+  },
+  "dependencies": {
+    "@repo/plugin-base": "*",
+    "@repo/types": "*",
+    "@repo/utils": "*",
+    "fuse.js": "^7.1.0"
+  },
+  "peerDependencies": {
+    "zod": "^4.1.13"
+  }
+}

--- a/packages/plugin-guess-the-tune/schema.ts
+++ b/packages/plugin-guess-the-tune/schema.ts
@@ -1,0 +1,184 @@
+import { z } from "zod"
+import type { PluginConfigSchema, PluginComponentSchema, PluginActionElement } from "@repo/types"
+import { guessTheTuneConfigSchema } from "./types"
+
+export function getComponentSchema(): PluginComponentSchema {
+  return {
+    components: [
+      {
+        id: "guess-tune-leaderboard-button",
+        type: "button",
+        area: "userList",
+        label: "Guess the Tune Leaderboard",
+        icon: "trophy",
+        opensModal: "guess-tune-leaderboard-modal",
+        showWhen: [
+          { field: "enabled", value: true },
+          { field: "showLeaderboard", value: true },
+        ],
+        variant: "solid",
+        size: "sm",
+      },
+      {
+        id: "guess-tune-leaderboard-modal",
+        type: "modal",
+        area: "userList",
+        title: "Guess the Tune Leaderboard",
+        size: "md",
+        showWhen: [
+          { field: "enabled", value: true },
+          { field: "showLeaderboard", value: true },
+        ],
+        children: [
+          {
+            id: "guess-tune-users-leaderboard",
+            type: "leaderboard",
+            area: "userList",
+            dataKey: "usersLeaderboard",
+            title: "Top players",
+            rowTemplate: [
+              {
+                type: "component",
+                name: "username",
+                props: { userId: "{{value}}", fallback: "{{username}}" },
+              },
+              { type: "text", content: ": {{score}} points" },
+            ],
+            maxItems: 25,
+            showRank: true,
+          },
+        ],
+      },
+    ],
+    storeKeys: ["usersLeaderboard"],
+  }
+}
+
+export function getConfigSchema(): PluginConfigSchema {
+  const resetAction = {
+    type: "action",
+    action: "resetLeaderboard",
+    label: "Reset leaderboard",
+    variant: "destructive",
+    confirmMessage:
+      "Reset all Guess the Tune scores? This cannot be undone.",
+    confirmText: "Reset leaderboard",
+    showWhen: { field: "enabled", value: true },
+  } satisfies PluginActionElement
+
+  return {
+    jsonSchema: z.toJSONSchema(guessTheTuneConfigSchema),
+    layout: [
+      { type: "heading", content: "Guess the Tune" },
+      {
+        type: "text-block",
+        content:
+          "Obscures now playing metadata and awards points when chat messages match the track (title, artist, or album).",
+        variant: "info",
+      },
+      "enabled",
+      "matchTitle",
+      "matchArtist",
+      "matchAlbum",
+      "pointsTitle",
+      "pointsArtist",
+      "pointsAlbum",
+      "speedMultiplier",
+      "speedMultiplierWindowSec",
+      "fuzzyThreshold",
+      "showNowPlayingToAdmins",
+      "showLeaderboard",
+      "soundEffectOnMatch",
+      "soundEffectOnMatchUrl",
+      "messageTemplate",
+      resetAction,
+    ],
+    fieldMeta: {
+      enabled: {
+        type: "boolean",
+        label: "Enable Guess the Tune",
+        description: "When enabled, now playing fields can be obscured and chat guesses score points.",
+      },
+      matchTitle: {
+        type: "boolean",
+        label: "Match track title",
+        showWhen: { field: "enabled", value: true },
+      },
+      matchArtist: {
+        type: "boolean",
+        label: "Match artist name",
+        showWhen: { field: "enabled", value: true },
+      },
+      matchAlbum: {
+        type: "boolean",
+        label: "Match album title",
+        showWhen: { field: "enabled", value: true },
+      },
+      pointsTitle: {
+        type: "number",
+        label: "Points — title",
+        showWhen: [{ field: "enabled", value: true }, { field: "matchTitle", value: true }],
+      },
+      pointsArtist: {
+        type: "number",
+        label: "Points — artist",
+        showWhen: [{ field: "enabled", value: true }, { field: "matchArtist", value: true }],
+      },
+      pointsAlbum: {
+        type: "number",
+        label: "Points — album",
+        showWhen: [{ field: "enabled", value: true }, { field: "matchAlbum", value: true }],
+      },
+      speedMultiplier: {
+        type: "number",
+        label: "Speed multiplier",
+        description: "Multiply points when a correct guess happens within the window below.",
+        showWhen: { field: "enabled", value: true },
+      },
+      speedMultiplierWindowSec: {
+        type: "number",
+        label: "Speed bonus window (seconds)",
+        description: "From track start: guesses within this many seconds get the multiplier.",
+        showWhen: { field: "enabled", value: true },
+      },
+      fuzzyThreshold: {
+        type: "number",
+        label: "Fuzzy match threshold (0–1)",
+        description: "Higher = more lenient (Fuse.js). Try 0.35–0.5.",
+        showWhen: { field: "enabled", value: true },
+      },
+      showNowPlayingToAdmins: {
+        type: "boolean",
+        label: "Show unobscured now playing to admins",
+        description:
+          "When off, admins see the same obscured UI as everyone else (client-side only).",
+        showWhen: { field: "enabled", value: true },
+      },
+      showLeaderboard: {
+        type: "boolean",
+        label: "Show leaderboard button",
+        showWhen: { field: "enabled", value: true },
+      },
+      soundEffectOnMatch: {
+        type: "boolean",
+        label: "Play sound on correct guess",
+        showWhen: { field: "enabled", value: true },
+      },
+      soundEffectOnMatchUrl: {
+        type: "url",
+        label: "Sound effect URL",
+        showWhen: [
+          { field: "enabled", value: true },
+          { field: "soundEffectOnMatch", value: true },
+        ],
+      },
+      messageTemplate: {
+        type: "string",
+        label: "System message template",
+        description:
+          "Variables: {{username}}, {{propertyLabel}}, {{points}}, {{multiplierSuffix}}",
+        showWhen: { field: "enabled", value: true },
+      },
+    },
+  }
+}

--- a/packages/plugin-guess-the-tune/schema.ts
+++ b/packages/plugin-guess-the-tune/schema.ts
@@ -55,6 +55,50 @@ export function getComponentSchema(): PluginComponentSchema {
 }
 
 export function getConfigSchema(): PluginConfigSchema {
+  const revealTitleAction = {
+    type: "action",
+    action: "revealTitle",
+    label: "Reveal track title for everyone",
+    variant: "outline",
+    confirmMessage:
+      "Show the real track title in Now Playing for all listeners? This does not award points.",
+    confirmText: "Reveal title",
+    showWhen: { field: "enabled", value: true },
+  } satisfies PluginActionElement
+
+  const revealArtistAction = {
+    type: "action",
+    action: "revealArtist",
+    label: "Reveal artist for everyone",
+    variant: "outline",
+    confirmMessage:
+      "Show the real artist name in Now Playing for all listeners? This does not award points.",
+    confirmText: "Reveal artist",
+    showWhen: { field: "enabled", value: true },
+  } satisfies PluginActionElement
+
+  const revealAlbumAction = {
+    type: "action",
+    action: "revealAlbum",
+    label: "Reveal album for everyone",
+    variant: "outline",
+    confirmMessage:
+      "Show the real album title in Now Playing for all listeners? This does not award points.",
+    confirmText: "Reveal album",
+    showWhen: { field: "enabled", value: true },
+  } satisfies PluginActionElement
+
+  const revealAllAction = {
+    type: "action",
+    action: "revealAll",
+    label: "Reveal all obscured fields",
+    variant: "outline",
+    confirmMessage:
+      "Reveal every obscured title, artist, and album field that applies to the current track? No points are awarded.",
+    confirmText: "Reveal all",
+    showWhen: { field: "enabled", value: true },
+  } satisfies PluginActionElement
+
   const resetAction = {
     type: "action",
     action: "resetLeaderboard",
@@ -91,6 +135,10 @@ export function getConfigSchema(): PluginConfigSchema {
       "soundEffectOnMatch",
       "soundEffectOnMatchUrl",
       "messageTemplate",
+      revealTitleAction,
+      revealArtistAction,
+      revealAlbumAction,
+      revealAllAction,
       resetAction,
     ],
     fieldMeta: {

--- a/packages/plugin-guess-the-tune/tsconfig.json
+++ b/packages/plugin-guess-the-tune/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  }
+}

--- a/packages/plugin-guess-the-tune/types.ts
+++ b/packages/plugin-guess-the-tune/types.ts
@@ -1,0 +1,49 @@
+import { z } from "zod"
+
+export const guessTheTuneConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  matchTitle: z.boolean().default(true),
+  matchArtist: z.boolean().default(true),
+  matchAlbum: z.boolean().default(true),
+  pointsTitle: z.number().int().min(0).default(5),
+  pointsArtist: z.number().int().min(0).default(2),
+  pointsAlbum: z.number().int().min(0).default(3),
+  speedMultiplier: z.number().min(1).default(2),
+  speedMultiplierWindowSec: z.number().int().min(0).default(20),
+  showNowPlayingToAdmins: z.boolean().default(true),
+  fuzzyThreshold: z.number().min(0).max(1).default(0.35),
+  soundEffectOnMatch: z.boolean().default(true),
+  soundEffectOnMatchUrl: z
+    .url()
+    .optional()
+    .default("https://ross-brown.s3.amazonaws.com/broadcast/correct.mp3"),
+  messageTemplate: z
+    .string()
+    .default(
+      "{{username}} identified the {{propertyLabel}}! +{{points}} points{{multiplierSuffix}}",
+    ),
+  showLeaderboard: z.boolean().default(true),
+})
+
+export type GuessTheTuneConfig = z.infer<typeof guessTheTuneConfigSchema>
+
+export const defaultGuessTheTuneConfig: GuessTheTuneConfig = {
+  enabled: false,
+  matchTitle: true,
+  matchArtist: true,
+  matchAlbum: true,
+  pointsTitle: 5,
+  pointsArtist: 2,
+  pointsAlbum: 3,
+  speedMultiplier: 2,
+  speedMultiplierWindowSec: 20,
+  showNowPlayingToAdmins: true,
+  fuzzyThreshold: 0.35,
+  soundEffectOnMatch: true,
+  soundEffectOnMatchUrl: "https://cdn.freesound.org/previews/650/650842_11771918-lq.mp3",
+  messageTemplate:
+    "{{username}} identified the {{propertyLabel}}! +{{points}} points{{multiplierSuffix}}",
+  showLeaderboard: true,
+}
+
+export type GuessProperty = "title" | "artist" | "album"

--- a/packages/plugin-playlist-democracy/index.ts
+++ b/packages/plugin-playlist-democracy/index.ts
@@ -1,5 +1,6 @@
 import type {
   Plugin,
+  PluginActionInitiator,
   PluginContext,
   PluginConfigSchema,
   PluginComponentSchema,
@@ -683,7 +684,10 @@ export class PlaylistDemocracyPlugin extends BasePlugin<PlaylistDemocracyConfig>
   // Actions
   // ============================================================================
 
-  async executeAction(action: string): Promise<{ success: boolean; message?: string }> {
+  async executeAction(
+    action: string,
+    _initiator?: PluginActionInitiator,
+  ): Promise<{ success: boolean; message?: string }> {
     if (action === "resetCompetitiveLeaderboard") {
       return this.resetCompetitiveLeaderboard()
     }

--- a/packages/plugin-special-words/index.ts
+++ b/packages/plugin-special-words/index.ts
@@ -1,5 +1,6 @@
 import type {
   Plugin,
+  PluginActionInitiator,
   PluginContext,
   PluginConfigSchema,
   PluginComponentSchema,
@@ -437,7 +438,10 @@ export class SpecialWordsPlugin extends BasePlugin<SpecialWordsConfig> {
   // Actions
   // ============================================================================
 
-  async executeAction(action: string): Promise<{ success: boolean; message?: string }> {
+  async executeAction(
+    action: string,
+    _initiator?: PluginActionInitiator,
+  ): Promise<{ success: boolean; message?: string }> {
     if (action === "resetLeaderboards") {
       return this.resetLeaderboards()
     }

--- a/packages/server/controllers/adminController.ts
+++ b/packages/server/controllers/adminController.ts
@@ -94,6 +94,9 @@ export function createAdminController(socket: SocketWithContext, io: Server): vo
       socket.data.roomId,
       pluginName,
       action,
+      socket.data.userId
+        ? { userId: socket.data.userId, username: socket.data.username }
+        : undefined,
     )
 
     socket.emit("event", {

--- a/packages/server/lib/plugins/PluginRegistry.ts
+++ b/packages/server/lib/plugins/PluginRegistry.ts
@@ -1,6 +1,7 @@
 import {
   AppContext,
   Plugin,
+  PluginActionInitiator,
   PluginContext,
   PluginLifecycleEvents,
   PluginSchemaInfo,
@@ -571,12 +572,14 @@ export class PluginRegistry {
    * @param roomId - The room where the plugin is active
    * @param pluginName - The plugin to execute the action on
    * @param action - The action identifier
+   * @param initiator - Acting admin user from the admin socket (optional)
    * @returns Result with success status and optional message
    */
   async executePluginAction(
     roomId: string,
     pluginName: string,
     action: string,
+    initiator?: PluginActionInitiator,
   ): Promise<{ success: boolean; message?: string }> {
     const roomPlugins = this.roomPlugins.get(roomId)
     if (!roomPlugins) {
@@ -594,7 +597,7 @@ export class PluginRegistry {
     }
 
     try {
-      return await plugin.executeAction(action)
+      return await plugin.executeAction(action, initiator)
     } catch (error) {
       console.error(
         `[PluginRegistry] Error executing action ${action} for plugin ${pluginName}:`,

--- a/packages/server/lib/plugins/PluginStorage.ts
+++ b/packages/server/lib/plugins/PluginStorage.ts
@@ -243,6 +243,44 @@ export class PluginStorageImpl implements PluginStorage {
     }
   }
 
+  async hget(key: string, field: string): Promise<string | null> {
+    try {
+      const v = await this.context.redis.pubClient.hGet(this.makeKey(key), field)
+      return v ?? null
+    } catch (error) {
+      console.error(`[PluginStorage] Error hget ${key}.${field}:`, error)
+      return null
+    }
+  }
+
+  async hset(key: string, field: string, value: string): Promise<void> {
+    try {
+      await this.context.redis.pubClient.hSet(this.makeKey(key), field, value)
+    } catch (error) {
+      console.error(`[PluginStorage] Error hset ${key}.${field}:`, error)
+    }
+  }
+
+  async hgetall(key: string): Promise<Record<string, string>> {
+    try {
+      const all = await this.context.redis.pubClient.hGetAll(this.makeKey(key))
+      return all ?? {}
+    } catch (error) {
+      console.error(`[PluginStorage] Error hgetall ${key}:`, error)
+      return {}
+    }
+  }
+
+  async hsetnx(key: string, field: string, value: string): Promise<boolean> {
+    try {
+      const n = await this.context.redis.pubClient.hSetNX(this.makeKey(key), field, value)
+      return Boolean(n)
+    } catch (error) {
+      console.error(`[PluginStorage] Error hsetnx ${key}.${field}:`, error)
+      return false
+    }
+  }
+
   /**
    * Cleanup all keys for this plugin in this room
    */

--- a/packages/types/Plugin.ts
+++ b/packages/types/Plugin.ts
@@ -172,6 +172,15 @@ export interface PluginStorage {
   zremrangebyscore(key: string, min: number, max: number): Promise<void>
   zscore(key: string, value: string): Promise<number | null>
   zincrby(key: string, increment: number, value: string): Promise<number>
+
+  /** Redis hash: get one field */
+  hget(key: string, field: string): Promise<string | null>
+  /** Redis hash: set one field */
+  hset(key: string, field: string, value: string): Promise<void>
+  /** Redis hash: get all fields */
+  hgetall(key: string): Promise<Record<string, string>>
+  /** Redis hash: set field only if it does not exist. Returns true if set. */
+  hsetnx(key: string, field: string, value: string): Promise<boolean>
 }
 
 /**
@@ -337,12 +346,44 @@ export interface PluginStyleHints {
 }
 
 /**
+ * Now-playing UI slots plugins may annotate via {@link PluginAugmentationData.elementProps}.
+ */
+export type PluginElementKey = "title" | "artist" | "album" | "artwork"
+
+/**
+ * Roles that may bypass {@link PluginElementProps.obscured} in the web client.
+ * Advisory only — not an authorization boundary (see ADR 0039).
+ */
+export type PluginObscureBypassRole = "admin" | "dj" | "creator" | "owner"
+
+/**
+ * Text/metadata slots (excludes artwork).
+ */
+export type PluginTextElementKey = Exclude<PluginElementKey, "artwork">
+
+export interface PluginElementProps {
+  obscured?: boolean
+  /**
+   * Roles for which this element should not be obscured even when `obscured` is true.
+   * The UI resolves this against the current viewer's roles.
+   */
+  obscureBypassRoles?: PluginObscureBypassRole[]
+  revealedBy?: { userId: string; username: string; at: number } | null
+  placeholder?: string
+}
+
+/**
  * Plugin data returned from augmentation methods.
  * Can include style hints and any plugin-specific metadata.
  */
 export interface PluginAugmentationData {
   /** Optional style modifications for UI elements */
   styles?: PluginStyleHints
+  /**
+   * Declarative hints for Now Playing slots (obscured, bypass roles, etc.).
+   * Merged per-plugin under `QueueItem.pluginData[pluginName]`.
+   */
+  elementProps?: Partial<Record<PluginElementKey, PluginElementProps>>
   /** Any other plugin-specific data */
   [key: string]: any
 }

--- a/packages/types/Plugin.ts
+++ b/packages/types/Plugin.ts
@@ -368,7 +368,15 @@ export interface PluginElementProps {
    * The UI resolves this against the current viewer's roles.
    */
   obscureBypassRoles?: PluginObscureBypassRole[]
-  revealedBy?: { userId: string; username: string; at: number } | null
+  /**
+   * When a slot is no longer obscured, optional attribution (e.g. Guess the Tune: who matched in chat, or admin reveal).
+   */
+  revealedBy?: {
+    userId: string
+    username: string
+    at: number
+    source?: "chat" | "admin"
+  } | null
   placeholder?: string
 }
 
@@ -431,6 +439,15 @@ export const rejectQueueRequest = (reason: string): QueueValidationResult => ({
 })
 
 /**
+ * Caller identity for admin-triggered plugin actions (e.g. config UI action buttons).
+ * Populated server-side from the admin Socket.IO connection; not sent from the client payload.
+ */
+export interface PluginActionInitiator {
+  userId: string
+  username?: string
+}
+
+/**
  * Base plugin interface
  */
 export interface Plugin {
@@ -481,10 +498,11 @@ export interface Plugin {
    * Actions are triggered from the admin config UI via action buttons.
    *
    * @param action - The action identifier from PluginActionElement
+   * @param initiator - Present when the action was triggered from the admin plugin config UI
    * @returns Result with success status and optional message
    *
    * @example
-   * async executeAction(action: string): Promise<{ success: boolean; message?: string }> {
+   * async executeAction(action: string, initiator?: PluginActionInitiator): Promise<{ success: boolean; message?: string }> {
    *   if (action === 'resetLeaderboards') {
    *     await this.clearAllLeaderboards()
    *     return { success: true, message: 'Leaderboards reset successfully' }
@@ -492,7 +510,10 @@ export interface Plugin {
    *   return { success: false, message: 'Unknown action' }
    * }
    */
-  executeAction?(action: string): Promise<{ success: boolean; message?: string }>
+  executeAction?(
+    action: string,
+    initiator?: PluginActionInitiator,
+  ): Promise<{ success: boolean; message?: string }>
 
   /**
    * Validate a queue request before it is processed.


### PR DESCRIPTION
Adds a "Guess the tune" plugin that, when enabled:
- obscures the track title, artist, and album from the now playing area (client-side only, savvy users could view incoming server data to see the real answer)
- watches chat messages for a decent fuzzy match on any of these three properties
- reveals any correctly identified properties and awards points to the user who entered the text
- shows a leaderboard and includes scores in the final Room Export

**Considered:** user who identified is deputized as a DJ in order to add the next track. I decided against this because it _could_ be ripe for abuse (person guessing their own tracks) and it may not always be the desire of the guesser to have to queue something up. For now we can do this manually until it becomes clear that there's a need for automation around it.

Idea submitted by @joeynotjoe