### PR TITLE
Admin Big Brother tab

### DIFF
--- a/apps/studio-bridge/src/payloads.ts
+++ b/apps/studio-bridge/src/payloads.ts
@@ -1,5 +1,10 @@
 import { marsEggSellbackValue } from "@repo/plugin-item-shops/mars-egg-sellback"
-import type { GameStateModifier } from "@repo/types/GameSession"
+import type {
+  GameAttributeName,
+  GameSession,
+  GameStateModifier,
+  UserGameState,
+} from "@repo/types/GameSession"
 import type { InventoryItem, ItemDefinition } from "@repo/types/Inventory"
 import type { QueueItem } from "@repo/types/Queue"
 import type { RoomMeta } from "@repo/types/Room"
@@ -77,7 +82,7 @@ function metaDisplayStringsFromQueueHead(
 export function buildRoomMeta(snap: BridgeSnapshot): Partial<RoomMeta> {
   const head = snap.queue[0]
   return {
-    stationMeta: {},
+    stationMeta: { bitrate: "" },
     nowPlaying: head ?? null,
     ...metaDisplayStringsFromQueueHead(head),
   }
@@ -114,6 +119,59 @@ export function buildUserGameStatePayload(snap: BridgeSnapshot, userId: string) 
       : null,
     itemDefinitions: snap.itemDefinitions,
     currentShopInstance,
+  }
+}
+
+const EMPTY_ATTRS = {} as Record<GameAttributeName, number>
+
+/** Admin tab: all users in the bridge snapshot with session-scoped state/inventory. */
+export function buildAllListenerGameStatesPayload(snap: BridgeSnapshot) {
+  const session = snap.activeSession
+  const maxSlots = session?.config.maxInventorySlots ?? DEFAULT_MAX_INVENTORY_SLOTS
+  if (!session) {
+    return {
+      session: null as GameSession | null,
+      listeners: [] as Array<{
+        userId: string
+        username: string
+        state: UserGameState
+        inventory: { userId: string; items: InventoryItem[]; maxSlots: number }
+      }>,
+      itemDefinitions: snap.itemDefinitions,
+    }
+  }
+
+  const defById = new Map<string, ItemDefinition>(snap.itemDefinitions.map((d) => [d.id, d]))
+
+  const listeners = snap.users.map((u) => {
+    const userId = u.userId
+    const state =
+      snap.userStates[userId] ??
+      ({ userId, attributes: EMPTY_ATTRS, modifiers: [], flags: {} } satisfies UserGameState)
+    const rawItems = snap.inventories[userId] ?? []
+    const items: InventoryItem[] =
+      rawItems.length > 0
+        ? rawItems.map((item) => {
+            const def = defById.get(item.definitionId)
+            if (def?.sourcePlugin === "item-shops" && def.shortId === "mars-egg") {
+              return { ...item, sellbackValue: marsEggSellbackValue(item, def) }
+            }
+            return item
+          })
+        : rawItems
+
+    return {
+      userId,
+      username: u.username?.trim() || userId,
+      state,
+      inventory: { userId, items, maxSlots },
+    }
+  })
+
+  return {
+    session,
+    listeners,
+    itemDefinitions: snap.itemDefinitions,
   }
 }
 

--- a/apps/studio-bridge/src/server.ts
+++ b/apps/studio-bridge/src/server.ts
@@ -8,6 +8,7 @@ import type { User } from "@repo/types/User"
 
 import type { BridgeSnapshot } from "./types.js"
 import {
+  buildAllListenerGameStatesPayload,
   buildInitPayload,
   buildRoomGameStateSnapshot,
   buildRoomMeta,
@@ -234,6 +235,26 @@ function wireSocketHandlers(io: IOServer): void {
       socket.emit("event", {
         type: "ROOM_GAME_STATE",
         data: buildRoomGameStateSnapshot(snap),
+      })
+    })
+
+    socket.on("GET_ALL_LISTENER_GAME_STATES", () => {
+      const roomId = socket.data.roomId as string | undefined
+      const snap = getBridgeSnapshot()
+      if (!roomId || !snap || snap.roomId !== roomId) {
+        socket.emit("event", {
+          type: "ALL_LISTENER_GAME_STATES",
+          data: {
+            session: null,
+            listeners: [],
+            itemDefinitions: [],
+          },
+        })
+        return
+      }
+      socket.emit("event", {
+        type: "ALL_LISTENER_GAME_STATES",
+        data: buildAllListenerGameStatesPayload(snap),
       })
     })
 

--- a/apps/web/src/actors/adminListenerStateActor.ts
+++ b/apps/web/src/actors/adminListenerStateActor.ts
@@ -1,0 +1,29 @@
+/**
+ * Admin listener game state actor
+ *
+ * Singleton for the admin "all listeners" tab. Activate only while that tab
+ * is visible (see ModalUserGameState).
+ */
+
+import { createActor } from "xstate"
+import {
+  adminListenerStateMachine,
+  type AllListenerGameStatesPayload,
+} from "../machines/adminListenerStateMachine"
+
+export const adminListenerStateActor = createActor(adminListenerStateMachine).start()
+
+export type { AllListenerGameStatesPayload }
+
+/** Request a fresh fetch (e.g. manual refresh). */
+export function refreshAdminListenerState(): void {
+  adminListenerStateActor.send({ type: "REFRESH" })
+}
+
+export function getAdminListenerPayload(): AllListenerGameStatesPayload | null {
+  return adminListenerStateActor.getSnapshot().context.payload
+}
+
+export function getAdminListenerError(): string | null {
+  return adminListenerStateActor.getSnapshot().context.error
+}

--- a/apps/web/src/components/Modals/GameState/AdminListenersTab.tsx
+++ b/apps/web/src/components/Modals/GameState/AdminListenersTab.tsx
@@ -1,0 +1,146 @@
+import { Box, Button, HStack, Spinner, Stack, Table, Text } from "@chakra-ui/react"
+import type { InventoryItem, ItemDefinition } from "@repo/types"
+import { useMemo } from "react"
+import {
+  useAdminListenerError,
+  useAdminListenerLoading,
+  useAdminListenerPayload,
+  refreshAdminListenerState,
+} from "../../../hooks/useActors"
+
+function formatNumber(n: number): string {
+  return new Intl.NumberFormat().format(n)
+}
+
+const EMPTY_DEFINITIONS: ItemDefinition[] = []
+
+function formatItemCell(
+  items: InventoryItem[],
+  definitionMap: Map<string, ItemDefinition>,
+): string {
+  if (items.length === 0) return "—"
+  return items
+    .map((it) => {
+      const name = definitionMap.get(it.definitionId)?.name ?? it.definitionId
+      return it.quantity > 1 ? `${name} ×${formatNumber(it.quantity)}` : name
+    })
+    .join(", ")
+}
+
+/**
+ * Room admin: table of session participants with score, coins, and inventory.
+ */
+export default function AdminListenersTab() {
+  const payload = useAdminListenerPayload()
+  const loading = useAdminListenerLoading()
+  const error = useAdminListenerError()
+
+  const definitionMap = useMemo(() => {
+    const map = new Map<string, ItemDefinition>()
+    for (const def of payload?.itemDefinitions ?? EMPTY_DEFINITIONS) {
+      map.set(def.id, def)
+    }
+    return map
+  }, [payload?.itemDefinitions])
+
+  const rows = useMemo(() => {
+    const list = payload?.listeners ?? []
+    return [...list].sort((a, b) =>
+      a.username.localeCompare(b.username, undefined, { sensitivity: "base" }),
+    )
+  }, [payload?.listeners])
+
+  if (loading && !payload) {
+    return (
+      <HStack py={2}>
+        <Spinner size="sm" />
+        <Text fontSize="sm" color="fg.muted">
+          Loading listener stats…
+        </Text>
+      </HStack>
+    )
+  }
+
+  if (error && !payload) {
+    return (
+      <Stack gap={3}>
+        <Text fontSize="sm" color="red.500">
+          {error}
+        </Text>
+        <Button size="sm" variant="outline" onClick={() => refreshAdminListenerState()}>
+          Retry
+        </Button>
+      </Stack>
+    )
+  }
+
+  if (!payload?.session) {
+    return (
+      <Text fontSize="sm" color="fg.muted">
+        No game session is running. Start a session in room settings to see listener stats.
+      </Text>
+    )
+  }
+
+  if (rows.length === 0) {
+    return (
+      <Stack gap={3}>
+        <Text fontSize="sm" color="fg.muted">
+          No session participants yet. Listeners appear here after they earn score, coins, or
+          items during this session.
+        </Text>
+        <Button
+          size="sm"
+          variant="outline"
+          alignSelf="flex-start"
+          loading={loading}
+          onClick={() => refreshAdminListenerState()}
+        >
+          Refresh
+        </Button>
+      </Stack>
+    )
+  }
+
+  return (
+    <Stack gap={3}>
+      <HStack justify="flex-end">
+        <Button size="xs" variant="ghost" loading={loading} onClick={() => refreshAdminListenerState()}>
+          Refresh
+        </Button>
+      </HStack>
+      <Box overflowX="auto" w="full" borderWidth="1px" borderRadius="md" borderColor="border.muted">
+        <Table.Root size="sm" variant="line">
+          <Table.Header>
+            <Table.Row>
+              <Table.ColumnHeader>Listener</Table.ColumnHeader>
+              <Table.ColumnHeader textAlign="end">Score</Table.ColumnHeader>
+              <Table.ColumnHeader textAlign="end">Coins</Table.ColumnHeader>
+              <Table.ColumnHeader>Items</Table.ColumnHeader>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {rows.map((row) => (
+              <Table.Row key={row.userId}>
+                <Table.Cell>
+                  <Text fontWeight="medium">{row.username}</Text>
+                </Table.Cell>
+                <Table.Cell textAlign="end">
+                  {formatNumber(row.state.attributes.score ?? 0)}
+                </Table.Cell>
+                <Table.Cell textAlign="end">
+                  {formatNumber(row.state.attributes.coin ?? 0)}
+                </Table.Cell>
+                <Table.Cell>
+                  <Text fontSize="sm" color="fg.muted">
+                    {formatItemCell(row.inventory.items, definitionMap)}
+                  </Text>
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table.Root>
+      </Box>
+    </Stack>
+  )
+}

--- a/apps/web/src/components/Modals/ModalUserGameState.tsx
+++ b/apps/web/src/components/Modals/ModalUserGameState.tsx
@@ -15,6 +15,8 @@ import {
   useUserGameStateLoading,
   useUserGameStateError,
   refreshUserGameState,
+  useIsAdmin,
+  useAdminListenerSend,
 } from "../../hooks/useActors"
 import { useGameStateNewPluginTabs } from "../GameStateNewPluginTabsProvider"
 import { getIcon } from "../PluginComponents/icons"
@@ -26,6 +28,7 @@ import {
   GameStatePluginTabContents,
 } from "./GameState"
 import StoredItemsTab from "./GameState/StoredItemsTab"
+import AdminListenersTab from "./GameState/AdminListenersTab"
 import { UserModifiersList } from "../UserModifiersList"
 
 function formatNumber(n: number): string {
@@ -36,6 +39,9 @@ const TROPHY_ICON = getIcon("trophy")
 const COINS_ICON = getIcon("coins")
 const PACKAGE_ICON = getIcon("package")
 const STORED_ICON = getIcon("Archive")
+const USERS_ICON = getIcon("Users")
+
+const ADMIN_LISTENERS_TAB = "admin"
 
 /** Stable fallbacks — `?? []` / `?? {}` in render create new references every paint and break effect deps / context (see Maximum update depth in studio-bridge preview). */
 const EMPTY_INVENTORY_ITEMS: InventoryItem[] = []
@@ -45,6 +51,8 @@ const EMPTY_ATTRIBUTES = {} as Record<GameAttributeName, number>
 function ModalUserGameState() {
   const modalSend = useModalsSend()
   const isOpen = useIsModalOpen("gameState")
+  const isAdmin = useIsAdmin()
+  const sendAdminListener = useAdminListenerSend()
   const { pluginTabs, unseenPluginTabIds, markPluginTabViewed } = useGameStateNewPluginTabs()
   const [gameStateTab, setGameStateTab] = useState("inventory")
 
@@ -57,6 +65,17 @@ function ModalUserGameState() {
       refreshUserGameState()
     }
   }, [isOpen])
+
+  useEffect(() => {
+    if (isOpen && isAdmin && gameStateTab === ADMIN_LISTENERS_TAB) {
+      sendAdminListener({ type: "ACTIVATE" })
+      return () => {
+        sendAdminListener({ type: "DEACTIVATE" })
+      }
+    }
+    sendAdminListener({ type: "DEACTIVATE" })
+    return undefined
+  }, [isOpen, isAdmin, gameStateTab, sendAdminListener])
 
   const definitionMap = useMemo(() => {
     const map = new Map<string, ItemDefinition>()
@@ -104,11 +123,14 @@ function ModalUserGameState() {
     if (showStoredTab) {
       ids.add("stored")
     }
+    if (isAdmin) {
+      ids.add(ADMIN_LISTENERS_TAB)
+    }
     for (const t of pluginTabs) {
       ids.add(t.id)
     }
     return ids
-  }, [pluginTabs, showStoredTab])
+  }, [pluginTabs, showStoredTab, isAdmin])
 
   useEffect(() => {
     if (!validTabValues.has(gameStateTab)) {
@@ -210,6 +232,12 @@ function ModalUserGameState() {
                   </Tabs.Trigger>
                 ) : null}
                 <GameStatePluginTabTriggers tabs={pluginTabs} unseenTabIds={unseenPluginTabIds} />
+                {isAdmin ? (
+                  <Tabs.Trigger value={ADMIN_LISTENERS_TAB}>
+                    {USERS_ICON ? <SvgIcon icon={USERS_ICON} mr={1} /> : null}
+                    All listeners
+                  </Tabs.Trigger>
+                ) : null}
               </Tabs.List>
 
               <Tabs.Content value="inventory">
@@ -230,6 +258,12 @@ function ModalUserGameState() {
               ) : null}
 
               <GameStatePluginTabContents tabs={pluginTabs} />
+
+              {isAdmin ? (
+                <Tabs.Content value={ADMIN_LISTENERS_TAB}>
+                  <AdminListenersTab />
+                </Tabs.Content>
+              ) : null}
             </Tabs.Root>
           )}
         </Stack>

--- a/apps/web/src/components/Modals/ModalUserGameState.tsx
+++ b/apps/web/src/components/Modals/ModalUserGameState.tsx
@@ -35,11 +35,11 @@ function formatNumber(n: number): string {
   return new Intl.NumberFormat().format(n)
 }
 
-const TROPHY_ICON = getIcon("trophy")
-const COINS_ICON = getIcon("coins")
-const PACKAGE_ICON = getIcon("package")
+const TROPHY_ICON = getIcon("Trophy")
+const COINS_ICON = getIcon("Coins")
+const PACKAGE_ICON = getIcon("Backpack")
 const STORED_ICON = getIcon("Archive")
-const USERS_ICON = getIcon("Users")
+const EYE_ICON = getIcon("Eye")
 
 const ADMIN_LISTENERS_TAB = "admin"
 
@@ -86,7 +86,10 @@ function ModalUserGameState() {
   }, [payload?.itemDefinitions])
 
   const enabledAttributes = payload?.session?.config.enabledAttributes ?? []
-  const attributes = (payload?.state?.attributes ?? EMPTY_ATTRIBUTES) as Record<GameAttributeName, number>
+  const attributes = (payload?.state?.attributes ?? EMPTY_ATTRIBUTES) as Record<
+    GameAttributeName,
+    number
+  >
   const inventoryEnabled = payload?.session?.config.inventoryEnabled ?? false
   /** Empty inventory must not use a fresh `[]` from payload each snapshot (bridge/API often do `?? []`). */
   const rawInventoryItems = payload?.inventory?.items
@@ -234,8 +237,8 @@ function ModalUserGameState() {
                 <GameStatePluginTabTriggers tabs={pluginTabs} unseenTabIds={unseenPluginTabIds} />
                 {isAdmin ? (
                   <Tabs.Trigger value={ADMIN_LISTENERS_TAB}>
-                    {USERS_ICON ? <SvgIcon icon={USERS_ICON} mr={1} /> : null}
-                    All listeners
+                    {EYE_ICON ? <SvgIcon icon={EYE_ICON} mr={1} /> : null}
+                    Big Brother
                   </Tabs.Trigger>
                 ) : null}
               </Tabs.List>

--- a/apps/web/src/hooks/useActors.ts
+++ b/apps/web/src/hooks/useActors.ts
@@ -27,6 +27,11 @@ import {
   refreshUserGameState,
   type UserGameStatePayload,
 } from "../actors/userGameStateActor"
+import {
+  adminListenerStateActor,
+  refreshAdminListenerState,
+  type AllListenerGameStatesPayload,
+} from "../actors/adminListenerStateActor"
 import { roomGameStateActor } from "../actors/roomGameStateActor"
 import { sharedTickerActor } from "../actors/sharedTickerActor"
 import type { GameStateModifier } from "@repo/types"
@@ -77,6 +82,7 @@ const sendToBookmarks = boundSendRef(bookmarkedChatActor)
 const sendToChatScrollTarget = boundSendRef(chatScrollTargetActor)
 const sendToMetadataPreference = boundSendRef(metadataPreferenceActor)
 const sendToLobby = boundSendRef(lobbyActor)
+const sendToAdminListener = boundSendRef(adminListenerStateActor)
 
 // ============================================================================
 // Auth Hooks
@@ -461,6 +467,30 @@ export const useUserInventory = () => {
 export const useUserItemDefinitions = () => {
   return useSelector(userGameStateActor, (s) => s.context.payload?.itemDefinitions ?? [])
 }
+
+// ============================================================================
+// Admin listener snapshot (all participants — admin tab only)
+// ============================================================================
+
+export { refreshAdminListenerState }
+export type { AllListenerGameStatesPayload }
+
+export const useAdminListenerPayload = () => {
+  return useSelector(adminListenerStateActor, (s) => s.context.payload)
+}
+
+export const useAdminListenerLoading = () => {
+  return useSelector(
+    adminListenerStateActor,
+    (s) => s.matches("loading") || s.matches("refreshing"),
+  )
+}
+
+export const useAdminListenerError = () => {
+  return useSelector(adminListenerStateActor, (s) => s.context.error)
+}
+
+export const useAdminListenerSend = () => sendToAdminListener
 
 // ============================================================================
 // Room Game State Hooks

--- a/apps/web/src/machines/adminListenerStateMachine.ts
+++ b/apps/web/src/machines/adminListenerStateMachine.ts
@@ -25,7 +25,7 @@ export interface AllListenerGameStatesPayload {
   itemDefinitions: ItemDefinition[]
 }
 
-interface AdminListenerStateContext {
+export interface AdminListenerStateContext {
   subscriptionId: string | null
   payload: AllListenerGameStatesPayload | null
   error: string | null

--- a/apps/web/src/machines/adminListenerStateMachine.ts
+++ b/apps/web/src/machines/adminListenerStateMachine.ts
@@ -1,0 +1,194 @@
+/**
+ * Admin listener game state machine
+ *
+ * When the room admin opens the "All listeners" tab in the game state modal,
+ * subscribes to socket events and keeps a snapshot of every session
+ * participant's attributes and inventory in sync.
+ *
+ * Send ACTIVATE when the tab is shown, DEACTIVATE when hidden or the modal closes.
+ */
+
+import type { GameSession, ItemDefinition, UserGameState, UserInventory } from "@repo/types"
+import { setup, assign } from "xstate"
+import { emitToSocket, subscribeById, unsubscribeById } from "../actors/socketActor"
+
+export interface AdminListenerRow {
+  userId: string
+  username: string
+  state: UserGameState
+  inventory: UserInventory
+}
+
+export interface AllListenerGameStatesPayload {
+  session: GameSession | null
+  listeners: AdminListenerRow[]
+  itemDefinitions: ItemDefinition[]
+}
+
+interface AdminListenerStateContext {
+  subscriptionId: string | null
+  payload: AllListenerGameStatesPayload | null
+  error: string | null
+}
+
+type AdminListenerEvent =
+  | { type: "ACTIVATE" }
+  | { type: "DEACTIVATE" }
+  | { type: "REFRESH" }
+  | { type: "ALL_LISTENER_GAME_STATES"; data: AllListenerGameStatesPayload }
+  | { type: "GAME_STATE_CHANGED"; data?: unknown }
+  | { type: "INVENTORY_ITEM_ACQUIRED"; data?: { userId?: string } }
+  | { type: "INVENTORY_ITEM_REMOVED"; data?: { userId?: string } }
+  | { type: "INVENTORY_ITEM_USED"; data?: { userId?: string } }
+  | { type: "INVENTORY_ITEM_TRANSFERRED"; data?: { userId?: string } }
+  | { type: "USER_JOINED"; data?: unknown }
+  | { type: "USER_LEFT"; data?: unknown }
+  | { type: "GAME_SESSION_STARTED"; data?: unknown }
+  | { type: "GAME_SESSION_ENDED"; data?: unknown }
+  | { type: "ERROR_OCCURRED"; data?: { message?: string } }
+
+let subscriptionCounter = 0
+
+export const adminListenerStateMachine = setup({
+  types: {
+    context: {} as AdminListenerStateContext,
+    events: {} as AdminListenerEvent,
+  },
+  actions: {
+    subscribe: assign(({ self }) => {
+      const id = `adminListener-${self.id}-${++subscriptionCounter}`
+      subscribeById(id, { send: (event) => self.send(event as AdminListenerEvent) })
+      return { subscriptionId: id }
+    }),
+    unsubscribe: ({ context }) => {
+      if (context.subscriptionId) {
+        unsubscribeById(context.subscriptionId)
+      }
+    },
+    clearSubscriptionId: assign({
+      subscriptionId: () => null,
+    }),
+    requestData: () => {
+      emitToSocket("GET_ALL_LISTENER_GAME_STATES", {})
+    },
+    setPayload: assign(({ event }) => {
+      if (event.type !== "ALL_LISTENER_GAME_STATES") return {}
+      const d = event.data
+      return {
+        payload: {
+          session: d.session,
+          listeners: d.listeners ?? [],
+          itemDefinitions: d.itemDefinitions ?? [],
+        },
+        error: null,
+      }
+    }),
+    reset: assign({
+      subscriptionId: () => null,
+      payload: () => null,
+      error: () => null,
+    }),
+    setError: assign(({ event }) => {
+      if (event.type !== "ERROR_OCCURRED") return {}
+      return { error: event.data?.message ?? "Could not load listener stats." }
+    }),
+  },
+}).createMachine({
+  id: "adminListenerState",
+  initial: "idle",
+  context: {
+    subscriptionId: null,
+    payload: null,
+    error: null,
+  },
+  states: {
+    idle: {
+      on: {
+        ACTIVATE: "loading",
+      },
+    },
+    loading: {
+      entry: ["subscribe", "requestData"],
+      on: {
+        DEACTIVATE: {
+          target: "idle",
+          actions: ["unsubscribe", "reset"],
+        },
+        ALL_LISTENER_GAME_STATES: {
+          target: "ready",
+          actions: ["setPayload"],
+        },
+        ERROR_OCCURRED: {
+          target: "error",
+          actions: ["setError"],
+        },
+      },
+    },
+    ready: {
+      on: {
+        DEACTIVATE: {
+          target: "idle",
+          actions: ["unsubscribe", "reset"],
+        },
+        REFRESH: "refreshing",
+        ALL_LISTENER_GAME_STATES: {
+          actions: ["setPayload"],
+        },
+        GAME_STATE_CHANGED: {
+          actions: ["requestData"],
+        },
+        INVENTORY_ITEM_ACQUIRED: {
+          actions: ["requestData"],
+        },
+        INVENTORY_ITEM_REMOVED: {
+          actions: ["requestData"],
+        },
+        INVENTORY_ITEM_USED: {
+          actions: ["requestData"],
+        },
+        INVENTORY_ITEM_TRANSFERRED: {
+          actions: ["requestData"],
+        },
+        USER_JOINED: {
+          actions: ["requestData"],
+        },
+        USER_LEFT: {
+          actions: ["requestData"],
+        },
+        GAME_SESSION_STARTED: {
+          actions: ["requestData"],
+        },
+        GAME_SESSION_ENDED: {
+          actions: ["requestData"],
+        },
+      },
+    },
+    refreshing: {
+      entry: ["requestData"],
+      on: {
+        DEACTIVATE: {
+          target: "idle",
+          actions: ["unsubscribe", "reset"],
+        },
+        ALL_LISTENER_GAME_STATES: {
+          target: "ready",
+          actions: ["setPayload"],
+        },
+        ERROR_OCCURRED: {
+          target: "error",
+          actions: ["setError"],
+        },
+      },
+    },
+    error: {
+      entry: ["unsubscribe", "clearSubscriptionId"],
+      on: {
+        DEACTIVATE: {
+          target: "idle",
+          actions: ["unsubscribe", "reset"],
+        },
+        REFRESH: "loading",
+      },
+    },
+  },
+})

--- a/packages/server/controllers/roomsController.ts
+++ b/packages/server/controllers/roomsController.ts
@@ -12,7 +12,9 @@ import {
   getRoomOnlineUsers,
   getRoomCurrent,
   getUser,
+  getUsersByIds,
 } from "../operations/data"
+import { isRoomAdmin } from "../operations/data/admins"
 import { checkUserChallenge } from "../operations/userChallenge"
 import * as scheduling from "../services/SchedulingService"
 import { RoomSnapshot } from "@repo/types/Room"
@@ -542,6 +544,93 @@ export function createRoomsController(socket: SocketWithContext, io: Server): vo
     socket.emit("event", {
       type: "ROOM_GAME_STATE",
       data: snapshot,
+    })
+  })
+
+  /**
+   * Room admins only: snapshot of every session participant's game state and
+   * inventory. Responds with `ALL_LISTENER_GAME_STATES` on this socket only.
+   */
+  socket.on("GET_ALL_LISTENER_GAME_STATES", async () => {
+    const room = await findRoomData({ context: socket.context, roomId: socket.data.roomId })
+    if (!room) {
+      socket.emit("event", {
+        type: "ERROR_OCCURRED",
+        data: { status: 404, error: "Not Found", message: "Room not found." },
+      })
+      return
+    }
+
+    const allowed = await isRoomAdmin({
+      context: socket.context,
+      roomId: socket.data.roomId,
+      userId: socket.data.userId,
+      roomCreator: room.creator,
+    })
+    if (!allowed) {
+      socket.emit("event", {
+        type: "ERROR_OCCURRED",
+        data: { status: 403, error: "Forbidden", message: "You are not a room admin." },
+      })
+      return
+    }
+
+    const gameSessions = socket.context.gameSessions
+    const inventory = socket.context.inventory
+
+    if (!gameSessions || !inventory) {
+      socket.emit("event", {
+        type: "ALL_LISTENER_GAME_STATES",
+        data: {
+          session: null,
+          listeners: [],
+          itemDefinitions: [],
+        },
+      })
+      return
+    }
+
+    const session = await gameSessions.getActiveSession(socket.data.roomId)
+    const itemDefinitions = await inventory.getAllItemDefinitions(socket.data.roomId)
+
+    if (!session) {
+      socket.emit("event", {
+        type: "ALL_LISTENER_GAME_STATES",
+        data: {
+          session: null,
+          listeners: [],
+          itemDefinitions,
+        },
+      })
+      return
+    }
+
+    const userIds = await gameSessions.getParticipantUserIds(socket.data.roomId)
+    const users = await getUsersByIds({ context: socket.context, userIds })
+    const usernameById = new Map(users.map((u) => [u.userId, u.username]))
+
+    const listeners = await Promise.all(
+      userIds.map(async (userId: string) => {
+        const [state, inv] = await Promise.all([
+          gameSessions.getUserState(socket.data.roomId, userId),
+          inventory.getInventory(socket.data.roomId, userId),
+        ])
+        return {
+          userId,
+          username: usernameById.get(userId)?.trim() || userId,
+          state,
+          inventory: inv,
+        }
+      }),
+    )
+
+    socket.emit("event", {
+      type: "ALL_LISTENER_GAME_STATES",
+      data: {
+        session,
+        listeners,
+        itemDefinitions,
+      },
     })
   })
 

--- a/packages/server/services/GameSessionService.ts
+++ b/packages/server/services/GameSessionService.ts
@@ -573,6 +573,17 @@ export class GameSessionService {
     return { sessionId: session.id, modifiersByUserId }
   }
 
+  /**
+   * User IDs in the active session's participants set (users who have touched
+   * session state at least once). Empty array when no active session.
+   */
+  async getParticipantUserIds(roomId: string): Promise<string[]> {
+    const session = await this.getActiveSession(roomId)
+    if (!session) return []
+    const ids = await this.context.redis.pubClient.sMembers(participantsKey(roomId, session.id))
+    return ids as string[]
+  }
+
   async getLeaderboard(
     roomId: string,
     leaderboardId: string,


### PR DESCRIPTION
Adds an admin-only "Big Brother" tab to the game state modal that shows all users, their points/coin, and inventory items.

<img width="602" height="405" alt="Screenshot 2026-05-15 at 7 17 44 AM" src="https://github.com/user-attachments/assets/47d9d02a-08b2-44b4-a258-1035d98e8094" />
