### PR TITLE
Replaces reconnection alerts instead of stacking

### DIFF
--- a/apps/web/src/lib/toasts.ts
+++ b/apps/web/src/lib/toasts.ts
@@ -1,24 +1,36 @@
 import { toaster } from "../components/ui/toaster"
 
+export const CONNECTION_STATUS_TOAST_ID = "connection-status"
+
 type ToastOptions = {
   title?: string
   description?: React.ReactNode
   type?: "success" | "error" | "warning" | "info" | "loading"
-  duration?: number
+  duration?: number | null
   status?: "success" | "error" | "warning" | "info"
+  id?: string
+  isClosable?: boolean
+}
+
+function resolveDuration(duration: number | null | undefined): number {
+  if (duration === null) return Infinity
+  if (duration === undefined) return 5000
+  return duration
 }
 
 export function toast(options: ToastOptions) {
   // Map legacy 'status' prop to 'type' for backwards compatibility
   const type = options.type || options.status || "info"
-  
+  const closable = options.isClosable ?? true
+
   return toaster.create({
+    id: options.id,
     title: options.title,
     description: options.description,
     type,
-    duration: options.duration ?? 5000,
+    duration: resolveDuration(options.duration),
     meta: {
-      closable: true,
+      closable,
     },
   })
 }

--- a/apps/web/src/machines/authMachine.ts
+++ b/apps/web/src/machines/authMachine.ts
@@ -11,7 +11,7 @@ import { Reaction } from "../types/Reaction"
 import { PlaylistItem } from "../types/PlaylistItem"
 import { ChatMessage } from "../types/ChatMessage"
 import { RoomMeta } from "../types/Room"
-import { toast } from "../lib/toasts"
+import { CONNECTION_STATUS_TOAST_ID, toast } from "../lib/toasts"
 
 export interface AuthContext {
   currentUser?: User
@@ -311,7 +311,7 @@ export const authMachine = setup({
         status: "warning",
         duration: null,
         isClosable: false,
-        id: "connection-status",
+        id: CONNECTION_STATUS_TOAST_ID,
       })
     },
     showReconnectingToast: ({ event }) => {
@@ -322,7 +322,7 @@ export const authMachine = setup({
           status: "info",
           duration: 2000,
           isClosable: false,
-          id: "connection-status",
+          id: CONNECTION_STATUS_TOAST_ID,
         })
       }
     },
@@ -333,7 +333,7 @@ export const authMachine = setup({
         status: "success",
         duration: 3000,
         isClosable: true,
-        id: "connection-status",
+        id: CONNECTION_STATUS_TOAST_ID,
       })
     },
     showReconnectFailedToast: () => {
@@ -343,7 +343,7 @@ export const authMachine = setup({
         status: "error",
         duration: null,
         isClosable: true,
-        id: "connection-status",
+        id: CONNECTION_STATUS_TOAST_ID,
       })
     },
     showNukeSuccessToast: () => {


### PR DESCRIPTION
Replaces connection status alerts instead of stacking them. When becoming disconnected, you'd see a stack of 3 alerts letting you know you had disconnected and it was trying to reconnect. This was annoying. This PR makes updates the reconnection flow to only show one connection status alert at a time.

https://github.com/user-attachments/assets/b9874751-87a0-4f40-8e1b-bed3aa4e4a07

