### PR TITLE
Adds PvG mode to guess the tune

### DIFF
--- a/apps/game-studio/src/studio/mockStudioPluginApi.ts
+++ b/apps/game-studio/src/studio/mockStudioPluginApi.ts
@@ -47,6 +47,11 @@ export class MockStudioPluginApi implements PluginAPI {
     })
   }
 
+  async isRoomAdmin(_roomId: string, userId: string): Promise<boolean> {
+    const user = this.room.users.get(userId)
+    return Boolean(user?.isAdmin)
+  }
+
   async skipTrack(_roomId: string, trackId: string): Promise<void> {
     const np = this.room.queue[0]
     if (np?.mediaSource.trackId === trackId) {

--- a/apps/web/src/components/Modals/Admin/PluginConfigForm.tsx
+++ b/apps/web/src/components/Modals/Admin/PluginConfigForm.tsx
@@ -713,7 +713,7 @@ function ActionButton({
 }) {
   const users = useUsers()
   const formFields = element.formFields
-  const hasForm = !!(formFields?.length)
+  const hasForm = !!formFields?.length
 
   const [isLoading, setIsLoading] = useState(false)
   const [formPopoverOpen, setFormPopoverOpen] = useState(false)

--- a/apps/web/src/components/NowPlaying/NowPlayingTrack.tsx
+++ b/apps/web/src/components/NowPlaying/NowPlayingTrack.tsx
@@ -24,6 +24,7 @@ import { usePluginStyles } from "../../hooks/usePluginStyles"
 import { usePluginElementProps } from "../../hooks/usePluginElementProps"
 import { usePreferredMetadataSource } from "../../hooks/useActors"
 import { MetadataSourceType } from "../../types/Queue"
+import { guessTheTuneNowPlayingItemContext } from "../../lib/guessTheTunePluginItemContext"
 import type { PluginElementProps } from "@repo/types"
 
 type RevealedBy = NonNullable<PluginElementProps["revealedBy"]>
@@ -131,6 +132,11 @@ export function NowPlayingTrack({ meta, room, users }: NowPlayingTrackProps) {
   const albumElementProps = usePluginElementProps(nowPlaying?.pluginData, "album")
   const artworkElementProps = usePluginElementProps(nowPlaying?.pluginData, "artwork")
 
+  const nowPlayingInfoItemContext = useMemo(
+    () => guessTheTuneNowPlayingItemContext(nowPlaying?.pluginData),
+    [nowPlaying?.pluginData],
+  )
+
   const djUser = dj ?? nowPlaying?.addedBy ?? null
   const djUsername = useMemo(
     () =>
@@ -221,7 +227,7 @@ export function NowPlayingTrack({ meta, room, users }: NowPlayingTrackProps) {
               position="relative"
               zIndex={1}
             >
-              <PluginArea area="nowPlayingInfo" />
+              <PluginArea area="nowPlayingInfo" itemContext={nowPlayingInfoItemContext} />
             </Box>
 
             <MetadataSourceInfo metadataSource={activeMetadataSource} />

--- a/apps/web/src/components/PluginComponents/PluginArea.tsx
+++ b/apps/web/src/components/PluginComponents/PluginArea.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react"
-import { Stack } from "@chakra-ui/react"
+import { Stack, Wrap } from "@chakra-ui/react"
 import { PluginComponentProvider, PluginComponentRenderer } from "./PluginComponentRenderer"
 import { usePluginSchemas } from "../../hooks/usePluginSchemas"
 import { usePluginConfigs } from "../../hooks/useActors"
@@ -84,7 +84,12 @@ export function PluginArea({
   }
 
   return (
-    <Stack direction={direction} gap={spacing} color={color} align={direction === "row" ? "center" : undefined}>
+    <Wrap
+      direction={direction}
+      gap={spacing}
+      color={color}
+      align={direction === "row" ? "center" : undefined}
+    >
       {pluginsForArea.map(({ pluginName, config, storeKeys, components }) => (
         <PluginComponentProvider
           key={pluginName}
@@ -102,6 +107,6 @@ export function PluginArea({
             ))}
         </PluginComponentProvider>
       ))}
-    </Stack>
+    </Wrap>
   )
 }

--- a/apps/web/src/components/PluginComponents/templates/ButtonComponent.tsx
+++ b/apps/web/src/components/PluginComponents/templates/ButtonComponent.tsx
@@ -32,6 +32,7 @@ export function ButtonTemplateComponent({
   confirmText,
   variant = "ghost",
   size = "sm",
+  colorPalette,
   disabled,
   pluginName,
 }: ButtonTemplateComponentProps) {
@@ -111,6 +112,7 @@ export function ButtonTemplateComponent({
     <Button
       size={size}
       variant={variant as never}
+      colorPalette={colorPalette}
       loading={isLoading}
       disabled={disabled}
       onClick={handleClick}
@@ -125,10 +127,10 @@ export function ButtonTemplateComponent({
       <Popover.Root open={confirmOpen} onOpenChange={(e) => setConfirmOpen(e.open)}>
         <Popover.Trigger asChild>{buttonNode}</Popover.Trigger>
         <Popover.Positioner>
-          <Popover.Content>
+          <Popover.Content css={{ "--popover-bg": "{colors.appBg}" }} color="fg">
             <Popover.Arrow />
             <Popover.Body>
-              <Text>{confirmMessage}</Text>
+              <Text fontSize="sm">{confirmMessage}</Text>
             </Popover.Body>
             <Popover.Footer justifyContent="flex-end" display="flex">
               <Button variant="plain" size="sm" onClick={() => setConfirmOpen(false)}>

--- a/apps/web/src/hooks/resolvePluginElementProps.test.ts
+++ b/apps/web/src/hooks/resolvePluginElementProps.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest"
+import { resolvePluginElementProps } from "./resolvePluginElementProps"
+
+const GTT_PLUGIN = "guess-the-tune"
+
+function inclusivePluginData(userReveals: Record<string, unknown>) {
+  return {
+    [GTT_PLUGIN]: {
+      elementProps: {
+        artwork: { obscured: true },
+        artist: { obscured: true, placeholder: "???" },
+        album: { obscured: true, placeholder: "???" },
+        title: { obscured: true, placeholder: "???" },
+      },
+      userReveals,
+    },
+  }
+}
+
+describe("resolvePluginElementProps userReveals (inclusive mode)", () => {
+  const enabledPlugins = new Set([GTT_PLUGIN])
+  const pluginConfigs = {
+    [GTT_PLUGIN]: { enabled: true, matchTitle: true, matchArtist: true, matchAlbum: true },
+  }
+
+  it("unobscures artist and album for the viewer with per-user reveals", () => {
+    const pluginData = inclusivePluginData({
+      u1: {
+        artist: { userId: "u1", username: "Alice", at: 1 },
+        album: { userId: "u1", username: "Alice", at: 2 },
+      },
+    })
+
+    const artist = resolvePluginElementProps({
+      pluginData,
+      element: "artist",
+      viewerUserId: "u1",
+      viewerRoles: [],
+      enabledPlugins,
+      pluginConfigs,
+    })
+    const album = resolvePluginElementProps({
+      pluginData,
+      element: "album",
+      viewerUserId: "u1",
+      viewerRoles: [],
+      enabledPlugins,
+      pluginConfigs,
+    })
+
+    expect(artist.obscured).toBe(false)
+    expect(artist.revealedBy?.userId).toBe("u1")
+    expect(album.obscured).toBe(false)
+  })
+
+  it("unobscures artwork for the viewer once they have revealed artist and album", () => {
+    const pluginData = inclusivePluginData({
+      u1: {
+        artist: { userId: "u1", username: "Alice", at: 1 },
+        album: { userId: "u1", username: "Alice", at: 2 },
+      },
+    })
+
+    const artworkForViewer = resolvePluginElementProps({
+      pluginData,
+      element: "artwork",
+      viewerUserId: "u1",
+      viewerRoles: [],
+      enabledPlugins,
+      pluginConfigs,
+    })
+    const artworkForOther = resolvePluginElementProps({
+      pluginData,
+      element: "artwork",
+      viewerUserId: "u2",
+      viewerRoles: [],
+      enabledPlugins,
+      pluginConfigs,
+    })
+
+    expect(artworkForViewer.obscured).toBe(false)
+    expect(artworkForOther.obscured).toBe(true)
+  })
+
+  it("keeps artwork obscured when only one of artist or album is revealed for the viewer", () => {
+    const pluginData = inclusivePluginData({
+      u1: {
+        artist: { userId: "u1", username: "Alice", at: 1 },
+      },
+    })
+
+    const artwork = resolvePluginElementProps({
+      pluginData,
+      element: "artwork",
+      viewerUserId: "u1",
+      viewerRoles: [],
+      enabledPlugins,
+      pluginConfigs,
+    })
+
+    expect(artwork.obscured).toBe(true)
+  })
+})

--- a/apps/web/src/hooks/resolvePluginElementProps.ts
+++ b/apps/web/src/hooks/resolvePluginElementProps.ts
@@ -1,0 +1,136 @@
+import type {
+  PluginElementKey,
+  PluginElementProps,
+  PluginObscureBypassRole,
+  PluginTextElementKey,
+  PluginUserReveals,
+} from "@repo/types"
+
+export interface ResolvedPluginElementProps extends PluginElementProps {
+  /** Final obscured flag after applying viewer bypass roles */
+  obscured: boolean
+}
+
+function applyUserRevealToTextElement(
+  element: PluginElementKey,
+  slice: PluginElementProps,
+  userReveals: PluginUserReveals | undefined,
+  viewerUserId: string | undefined,
+): PluginElementProps {
+  if (!viewerUserId || !userReveals) return slice
+  if (element === "artwork") return slice
+
+  const textKey = element as PluginTextElementKey
+  const userRev = userReveals[viewerUserId]?.[textKey]
+  if (!userRev) return slice
+
+  return {
+    ...slice,
+    obscured: false,
+    revealedBy: userRev,
+  }
+}
+
+function mergeRawElementProps(
+  pluginData: Record<string, unknown> | undefined,
+  element: PluginElementKey,
+  enabledPlugins: Set<string>,
+  viewerUserId?: string,
+): PluginElementProps {
+  if (!pluginData) return {}
+
+  const bypass = new Set<PluginObscureBypassRole>()
+  let revealedBy: PluginElementProps["revealedBy"]
+  let anyObscured = false
+  let placeholder: string | undefined
+
+  const names = Object.keys(pluginData).sort()
+  for (const pluginName of names) {
+    if (!enabledPlugins.has(pluginName)) continue
+    const data = pluginData[pluginName] as Record<string, unknown> | undefined
+    const ep = data?.elementProps as Partial<Record<PluginElementKey, PluginElementProps>> | undefined
+    const userReveals = data?.userReveals as PluginUserReveals | undefined
+    let slice = ep?.[element]
+    if (!slice) continue
+
+    slice = applyUserRevealToTextElement(element, slice, userReveals, viewerUserId)
+
+    if (slice.obscureBypassRoles?.length) {
+      for (const r of slice.obscureBypassRoles) bypass.add(r)
+    }
+    if (slice.placeholder != null) placeholder = slice.placeholder
+    if (slice.revealedBy) revealedBy = slice.revealedBy
+    if (slice.obscured === true) anyObscured = true
+  }
+
+  const obscured = Boolean(anyObscured && !revealedBy)
+
+  return {
+    obscured,
+    obscureBypassRoles: bypass.size ? Array.from(bypass) : undefined,
+    revealedBy: revealedBy ?? undefined,
+    placeholder,
+  }
+}
+
+function applyObscureBypass(
+  raw: PluginElementProps,
+  viewerRoles: PluginObscureBypassRole[],
+): ResolvedPluginElementProps {
+  const bypass =
+    raw.obscured && raw.obscureBypassRoles?.some((r) => viewerRoles.includes(r))
+
+  return {
+    ...raw,
+    obscured: Boolean(raw.obscured && !bypass),
+  }
+}
+
+export interface ResolvePluginElementPropsInput {
+  pluginData: Record<string, unknown> | undefined
+  element: PluginElementKey
+  viewerUserId?: string
+  viewerRoles: PluginObscureBypassRole[]
+  enabledPlugins: Set<string>
+  pluginConfigs: Record<string, unknown> | undefined
+}
+
+export function resolvePluginElementProps({
+  pluginData,
+  element,
+  viewerUserId,
+  viewerRoles,
+  enabledPlugins,
+  pluginConfigs,
+}: ResolvePluginElementPropsInput): ResolvedPluginElementProps {
+  if (element === "artwork") {
+    const rawArtwork = mergeRawElementProps(pluginData, "artwork", enabledPlugins, viewerUserId)
+    const artist = applyObscureBypass(
+      mergeRawElementProps(pluginData, "artist", enabledPlugins, viewerUserId),
+      viewerRoles,
+    )
+    const album = applyObscureBypass(
+      mergeRawElementProps(pluginData, "album", enabledPlugins, viewerUserId),
+      viewerRoles,
+    )
+
+    const gttConfig = pluginConfigs?.["guess-the-tune"] as
+      | { matchArtist?: boolean; matchAlbum?: boolean }
+      | undefined
+    const artistBlocks = Boolean(gttConfig?.matchArtist && artist.obscured)
+    const albumBlocks = Boolean(gttConfig?.matchAlbum && album.obscured)
+    const obscuredFromMetadata = artistBlocks || albumBlocks
+
+    const bypass =
+      obscuredFromMetadata &&
+      rawArtwork.obscureBypassRoles?.some((r) => viewerRoles.includes(r))
+
+    return {
+      ...rawArtwork,
+      obscured: Boolean(obscuredFromMetadata && !bypass),
+    }
+  }
+
+  const raw = mergeRawElementProps(pluginData, element, enabledPlugins, viewerUserId)
+  return applyObscureBypass(raw, viewerRoles)
+}

--- a/apps/web/src/hooks/usePluginElementProps.ts
+++ b/apps/web/src/hooks/usePluginElementProps.ts
@@ -1,16 +1,16 @@
 import { useMemo } from "react"
-import type {
-  PluginElementKey,
-  PluginElementProps,
-  PluginObscureBypassRole,
-} from "@repo/types"
+import type { PluginElementKey } from "@repo/types"
 
 import {
   useIsAdmin,
   useIsRoomCreator,
   useCanAddToQueue,
   usePluginConfigs,
+  useCurrentUser,
 } from "./useActors"
+import { resolvePluginElementProps } from "./resolvePluginElementProps"
+import type { ResolvedPluginElementProps } from "./resolvePluginElementProps"
+import type { PluginObscureBypassRole } from "@repo/types"
 
 /**
  * Roles the current viewer has, for resolving {@link PluginElementProps.obscureBypassRoles}.
@@ -32,58 +32,20 @@ function usePluginObscureViewerRoles(): PluginObscureBypassRole[] {
   }, [isAdmin, isCreator, isDj])
 }
 
-function mergeRawElementProps(
-  pluginData: Record<string, unknown> | undefined,
-  element: PluginElementKey,
-  enabledPlugins: Set<string>,
-): PluginElementProps {
-  if (!pluginData) return {}
-
-  const bypass = new Set<PluginObscureBypassRole>()
-  let revealedBy: PluginElementProps["revealedBy"]
-  let anyObscured = false
-  let placeholder: string | undefined
-
-  const names = Object.keys(pluginData).sort()
-  for (const pluginName of names) {
-    if (!enabledPlugins.has(pluginName)) continue
-    const data = pluginData[pluginName] as Record<string, unknown> | undefined
-    const ep = data?.elementProps as Partial<Record<PluginElementKey, PluginElementProps>> | undefined
-    const slice = ep?.[element]
-    if (!slice) continue
-
-    if (slice.obscureBypassRoles?.length) {
-      for (const r of slice.obscureBypassRoles) bypass.add(r)
-    }
-    if (slice.placeholder != null) placeholder = slice.placeholder
-    if (slice.revealedBy) revealedBy = slice.revealedBy
-    if (slice.obscured === true) anyObscured = true
-  }
-
-  const obscured = Boolean(anyObscured && !revealedBy)
-
-  return {
-    obscured,
-    obscureBypassRoles: bypass.size ? Array.from(bypass) : undefined,
-    revealedBy: revealedBy ?? undefined,
-    placeholder,
-  }
-}
-
-export interface ResolvedPluginElementProps extends PluginElementProps {
-  /** Final obscured flag after applying viewer bypass roles */
-  obscured: boolean
-}
+export type { ResolvedPluginElementProps } from "./resolvePluginElementProps"
 
 /**
  * Merges `elementProps` from all plugins under `pluginData` and resolves
  * {@link PluginElementProps.obscureBypassRoles} against the current viewer.
+ * Applies {@link PluginAugmentationData.userReveals} for the current user when present.
  */
 export function usePluginElementProps(
   pluginData: Record<string, unknown> | undefined,
   element: PluginElementKey,
 ): ResolvedPluginElementProps {
   const viewerRoles = usePluginObscureViewerRoles()
+  const currentUser = useCurrentUser()
+  const viewerUserId = currentUser?.userId
   const pluginConfigs = usePluginConfigs()
   const enabledPlugins = useMemo(() => {
     const enabled = new Set<string>()
@@ -98,15 +60,16 @@ export function usePluginElementProps(
     return enabled
   }, [pluginConfigs])
 
-  return useMemo(() => {
-    const raw = mergeRawElementProps(pluginData, element, enabledPlugins)
-    const bypass =
-      raw.obscured &&
-      raw.obscureBypassRoles?.some((r) => viewerRoles.includes(r))
-
-    return {
-      ...raw,
-      obscured: Boolean(raw.obscured && !bypass),
-    }
-  }, [pluginData, element, viewerRoles, enabledPlugins])
+  return useMemo(
+    () =>
+      resolvePluginElementProps({
+        pluginData,
+        element,
+        viewerUserId,
+        viewerRoles,
+        enabledPlugins,
+        pluginConfigs,
+      }),
+    [pluginData, element, viewerRoles, enabledPlugins, viewerUserId, pluginConfigs],
+  )
 }

--- a/apps/web/src/lib/guessTheTunePluginItemContext.test.ts
+++ b/apps/web/src/lib/guessTheTunePluginItemContext.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest"
+import { guessTheTuneNowPlayingItemContext } from "./guessTheTunePluginItemContext"
+
+describe("guessTheTuneNowPlayingItemContext", () => {
+  it("returns undefined when guess-the-tune has no elementProps", () => {
+    expect(guessTheTuneNowPlayingItemContext(undefined)).toBeUndefined()
+    expect(guessTheTuneNowPlayingItemContext({})).toBeUndefined()
+    expect(guessTheTuneNowPlayingItemContext({ "guess-the-tune": {} })).toBeUndefined()
+  })
+
+  it("reflects room-level global obscured state", () => {
+    const ctx = guessTheTuneNowPlayingItemContext({
+      "guess-the-tune": {
+        elementProps: {
+          title: { obscured: true },
+          artist: { obscured: false, revealedBy: { userId: "admin", username: "Admin", at: 1 } },
+          album: { obscured: true },
+        },
+      },
+    })
+
+    expect(ctx).toEqual({
+      titleObscured: true,
+      artistObscured: false,
+      albumObscured: true,
+      anyObscured: true,
+    })
+  })
+
+  it("anyObscured is false when all present fields are globally revealed", () => {
+    const ctx = guessTheTuneNowPlayingItemContext({
+      "guess-the-tune": {
+        elementProps: {
+          title: { obscured: false },
+          artist: { obscured: false },
+        },
+      },
+    })
+
+    expect(ctx?.anyObscured).toBe(false)
+  })
+})

--- a/apps/web/src/lib/guessTheTunePluginItemContext.ts
+++ b/apps/web/src/lib/guessTheTunePluginItemContext.ts
@@ -1,0 +1,31 @@
+import type { PluginElementKey, PluginElementProps } from "@repo/types"
+
+const GUESS_THE_TUNE_PLUGIN = "guess-the-tune"
+
+/**
+ * Item context for Guess the Tune `nowPlayingInfo` plugin components.
+ *
+ * Uses room-level `elementProps` from augmentation (global reveals), not per-user
+ * `userReveals`. In inclusive mode per-user guesses keep room-level slots obscured
+ * until an admin global reveal.
+ */
+export function guessTheTuneNowPlayingItemContext(
+  pluginData: Record<string, unknown> | undefined,
+): Record<string, boolean> | undefined {
+  const data = pluginData?.[GUESS_THE_TUNE_PLUGIN] as
+    | { elementProps?: Partial<Record<PluginElementKey, PluginElementProps>> }
+    | undefined
+  const elementProps = data?.elementProps
+  if (!elementProps) return undefined
+
+  const titleObscured = elementProps.title?.obscured === true
+  const artistObscured = elementProps.artist?.obscured === true
+  const albumObscured = elementProps.album?.obscured === true
+
+  return {
+    titleObscured,
+    artistObscured,
+    albumObscured,
+    anyObscured: titleObscured || artistObscured || albumObscured,
+  }
+}

--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -374,9 +374,17 @@ async validateQueueRequest(params: QueueValidationParams): Promise<QueueValidati
 }
 ```
 
-#### `transformChatMessage(roomId, message): Promise<ChatMessage | null>` (optional)
+#### `transformChatMessage(roomId, message): Promise<ChatMessageTransformResult>` (optional)
 
-Transform a chat message **after** it is parsed (mentions, Mustache) but **before** it is broadcast and persisted. Plugins are called **in order**; each receives the previous plugin’s result. Return `null` to leave the message unchanged. Fail-open on errors and timeouts (500ms), like `validateQueueRequest`.
+Transform a chat message **after** it is parsed (mentions, Mustache) but **before** it is broadcast and persisted. Plugins are called **in order**; each receives the previous plugin’s result. Return type is `ChatMessageTransformResult`:
+
+| Return value | Effect |
+| ------------ | ------ |
+| `null` | Leave the message unchanged (pass through to the next plugin). |
+| `ChatMessage` | Use this message as input for the next plugin (and for send if no later plugin changes it). |
+| `{ drop: true, reason?: string }` | **Skip** persistence and broadcast for this user message. `sendMessage` is not called; the drop is silent on the wire. Plugins may still send separate system messages. Short-circuits the plugin chain. |
+
+Fail-open on errors and timeouts (500ms per plugin), like `validateQueueRequest`. Use `{ drop: true }` when a message would spoil hidden room state in inclusive participation modes (see [ADR 0062](adrs/0062-participation-mode-pvp-vs-pvg.md)). Matching and scoring for inclusive mode SHOULD happen in this hook so the drop decision is atomic with the award.
 
 To express per-span presentation (e.g. smaller text on part of a line), set **`message.contentSegments`** (typed `TextSegment[]` with declarative `TextEffect`s) and keep **`message.content`** as a matching plain string. See [ADR 0044](adrs/0044-plugin-chat-message-transform-and-text-segments.md). Helpers: `tokenizeWords` / `buildSegments` in `@repo/plugin-base/helpers`.
 
@@ -1307,6 +1315,45 @@ async augmentNowPlaying(item: QueueItem): Promise<PluginAugmentationData> {
   }
 }
 ```
+
+### `PluginAugmentationData` shape
+
+Augmentation methods return `PluginAugmentationData`, merged into `QueueItem.pluginData[pluginName]` on the client. Common fields:
+
+| Field | Description |
+| ----- | ----------- |
+| `elementProps` | Per-element now playing hints keyed by `title`, `artist`, `album`, or `artwork` (`PluginElementProps`: `obscured`, `placeholder`, `revealedBy`, `obscureBypassRoles`). See [ADR 0039](adrs/0039-plugin-element-properties-for-now-playing.md). |
+| `userReveals` | Per-user reveal overrides for **inclusive** participation modes ([ADR 0062](adrs/0062-participation-mode-pvp-vs-pvg.md)): map of `userId` → partial `title` / `artist` / `album` → `revealedBy`. Broadcast to all clients; the web client applies **only the current viewer’s row** when resolving `elementProps` (`usePluginElementProps` / `resolvePluginElementProps`). Plugins SHOULD cap payload size (e.g. 200 most recent users). Room-level `elementProps` may stay obscured while `userReveals` carries per-viewer overrides. |
+| `styles` | Legacy inline style hints for now playing text (prefer `elementProps` for new work). |
+| Other keys | Plugin-specific data (e.g. `skipped`, leaderboard hints). |
+
+Example with obscured fields and per-user reveals (Guess the Tune inclusive mode):
+
+```typescript
+async augmentNowPlaying(item: QueueItem): Promise<PluginAugmentationData> {
+  // ... load round state ...
+
+  return {
+    elementProps: {
+      title: { obscured: true, placeholder: "???" },
+      artist: { obscured: true, placeholder: "???" },
+      album: { obscured: true, placeholder: "???" },
+      artwork: { obscured: true },
+    },
+    userReveals: {
+      "user-a": {
+        title: { userId: "user-a", username: "Alice", at: Date.now(), source: "chat" },
+      },
+      "user-b": {
+        artist: { userId: "user-b", username: "Bob", at: Date.now(), source: "chat" },
+        album: { userId: "user-b", username: "Bob", at: Date.now(), source: "chat" },
+      },
+    },
+  }
+}
+```
+
+Admin-only plugin actions that mutate room state SHOULD verify `await this.context.api.isRoomAdmin(roomId, initiator.userId)` server-side even when the UI uses `adminOnly: true` on buttons ([ADR 0062](adrs/0062-participation-mode-pvp-vs-pvg.md)).
 
 ## Room Export
 

--- a/docs/adrs/0044-plugin-chat-message-transform-and-text-segments.md
+++ b/docs/adrs/0044-plugin-chat-message-transform-and-text-segments.md
@@ -9,7 +9,7 @@ Plugins could subscribe to `MESSAGE_RECEIVED` only after a message was finalized
 
 ## Decision
 
-1. Add **`Plugin.transformChatMessage(roomId, message): Promise<ChatMessage | null>`**, invoked sequentially by **`PluginRegistry.transformChatMessage`** from **`messageHandlersAdapter.newMessage`** immediately before **`sendMessage`**. Returning `null` leaves the message unchanged. Errors and per-plugin timeouts use **fail-open** semantics (500ms timeout), matching queue validation.
+1. Add **`Plugin.transformChatMessage(roomId, message): Promise<ChatMessageTransformResult>`**, invoked sequentially by **`PluginRegistry.transformChatMessage`** from **`messageHandlersAdapter.newMessage`** immediately before **`sendMessage`**. Returning `null` leaves the message unchanged. Returning **`{ drop: true }`** skips persistence and broadcast (see [ADR 0062](0062-participation-mode-pvp-vs-pvg.md)). Errors and per-plugin timeouts use **fail-open** semantics (500ms timeout), matching queue validation.
 2. Extend **`ChatMessage`** with **`contentSegments?: TextSegment[]`** and a typed **`TextEffect`** discriminated union (initial variant: `{ type: "size", value: "small" | "normal" | "large" }`). **`content`** remains the canonical plain string and must stay in sync for persistence and exports.
 3. The web client prefers **`contentSegments`** when present and maps effects to styles in **`apps/web/src/lib/textEffects.ts`** (declarative, similar in spirit to screen effects for animations).
 4. **`@repo/plugin-base/helpers/chatTransform.ts`** provides **`tokenizeWords`** and **`buildSegments`** so plugins can build segments without custom parsers.
@@ -31,6 +31,7 @@ Plugins could subscribe to `MESSAGE_RECEIVED` only after a message was finalized
 
 - [ADR 0006 — Plugin System](0006-plugin-system-for-room-features.md)
 - [ADR 0008 — SystemEvents and Broadcasters](0008-system-events-and-broadcaster-pattern.md)
+- [ADR 0062 — Participation mode (drop sentinel)](0062-participation-mode-pvp-vs-pvg.md)
 - `packages/server/lib/sendMessage.ts`
 - `packages/server/lib/plugins/PluginRegistry.ts`
 - `packages/server/handlers/messageHandlersAdapter.ts`

--- a/docs/adrs/0062-participation-mode-pvp-vs-pvg.md
+++ b/docs/adrs/0062-participation-mode-pvp-vs-pvg.md
@@ -1,0 +1,79 @@
+# 0062. Participation Mode (Competitive vs Inclusive)
+
+**Date:** 2026-06-15
+**Status:** Accepted
+
+## Context
+
+Platform game-mechanic plugins (Guess the Tune today; potentially others) often gate scarce rewards on user actions. The default pattern is **first-actor-wins** (competitive / PvP): one user resolves the round and others get nothing for the same action. At scale — many listeners in a room — this collapses to a handful of fast typers earning everything, which suppresses participation.
+
+Coin earning is a foundational platform incentive. We need a sanctioned, reusable **inclusive** alternative where every participant can earn independently, while still supporting competitive modes where appropriate.
+
+Guess the Tune is the first plugin to adopt both modes explicitly. Related patterns already exist elsewhere (special words, playlist democracy) but were not named or shared.
+
+## Decision
+
+### Participation modes
+
+Plugins that gate rewards on user actions SHOULD support two named modes when feasible:
+
+| Mode | Alias | Behavior |
+|------|-------|----------|
+| `competitive` | PvP | A single user resolves the round for everyone; others cannot earn for the same action. |
+| `inclusive` | PvG | Each user has an independent opportunity to earn, scored against the room/track itself rather than against each other. Leaderboards remain. |
+
+**Default:** New plugins SHOULD default to `inclusive`.
+
+Shared config helpers live in `@repo/game-logic` (`participationModeSchema`, `participationModeFieldMeta`, `isInclusiveMode`).
+
+### Per-user UI reveals
+
+Per-user UI overrides live in `QueueItem.pluginData[pluginName].userReveals[userId]`:
+
+- The map is **broadcast to all clients** (via existing playlist/now-playing augmentation).
+- Each client **only consults its own row** when resolving obscured now-playing fields (extends ADR 0039's `elementProps` with a per-viewer dimension).
+- Payload size is bounded: plugins SHOULD cap `userReveals` (e.g. 200 entries, viewer always included) rather than thread `userId` through socket-aware augmentation.
+
+This avoids private socket fan-out for every reveal while keeping the augmentation API unchanged.
+
+### Chat message drops (inclusive mode)
+
+In inclusive mode, chat messages that would spoil hidden state (e.g. a correct guess text) MUST NOT be persisted or broadcast. Plugins return `{ drop: true }` from `transformChatMessage` (extends ADR 0044). Matching and scoring for inclusive mode SHOULD happen in `transformChatMessage` so the drop decision is atomic with the award.
+
+System messages announce success to the room; the original user message is dropped silently.
+
+### Admin global reveals
+
+Admin-driven reveals (e.g. "reveal title for everyone") remain **global** in both modes and are enforced at the plugin level via `PluginAPI.isRoomAdmin`.
+
+### Candidate adopters
+
+| Feature | Notes |
+|---------|-------|
+| `plugin-special-words` | Already inclusive — cite as exemplar. |
+| `plugin-playlist-democracy` | Voting is already inclusive. |
+| `plugin-guess-the-tune` | First explicit adopter of the shared mode field and `userReveals`. |
+| Future games (lyric race, BPM/year guess, name the sample) | SHOULD ship `inclusive` first. |
+| Inventory item-targeting (ADR 0045, 0050) | Explicitly **competitive** — adversarial by design; out of scope. |
+
+## Consequences
+
+### Positive
+
+- **More participation at scale.** Inclusive mode extends coin-earning opportunities without removing leaderboard competition.
+- **Shared vocabulary.** `competitive` / `inclusive` and `@repo/game-logic` helpers reduce one-off plugin semantics.
+- **Reuses existing infrastructure.** `elementProps` (ADR 0039), `transformChatMessage` (ADR 0044), and plugin augmentation — extended, not replaced.
+
+### Negative / trade-offs
+
+- **`userReveals` broadcast size.** Capped maps trade perfect completeness for bounded payloads; clients only need their own row.
+- **Dual code paths.** Plugins supporting both modes maintain competitive (`MESSAGE_RECEIVED`) and inclusive (`transformChatMessage` + drop) paths.
+- **Drop is silent.** The sender's client does not see their suppressed message (no optimistic chat UI); acceptable for guess-the-tune spoilers.
+
+## References
+
+- [ADR 0006 — Plugin System](0006-plugin-system-for-room-features.md)
+- [ADR 0039 — Plugin elementProps for Now Playing](0039-plugin-element-properties-for-now-playing.md)
+- [ADR 0044 — Plugin Chat Message Transform](0044-plugin-chat-message-transform-and-text-segments.md) (amended by this ADR for `{ drop: true }`)
+- [ADR 0048 — Plugin User-Targeted Chat](0048-plugin-user-targeted-chat.md)
+- `packages/game-logic/src/participationMode.ts`

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -67,6 +67,7 @@ This directory contains Architectural Decision Records (ADRs) for the Listening 
 | [0059](0059-time-cop-playback-window-plugin.md) | Queue Pacer Playback Window Plugin | Accepted |
 | [0060](0060-playback-state-changed-system-event.md) | SYSTEM:PLAYBACK_STATE_CHANGED event | Accepted |
 | [0061](0061-poll-voting-as-core-feature.md) | Poll voting as a core feature (not a plugin) | Accepted |
+| [0062](0062-participation-mode-pvp-vs-pvg.md) | Participation mode (competitive vs inclusive) for game plugins | Accepted |
 
 ## Creating a New ADR
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16222,7 +16222,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@repo/types": "*"
+        "@repo/types": "*",
+        "zod": "^4.4.2"
       },
       "devDependencies": {
         "@repo/typescript-config": "*",
@@ -16262,6 +16263,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@repo/game-logic": "*",
         "@repo/plugin-base": "*",
         "@repo/types": "*",
         "@repo/utils": "*",
@@ -18118,7 +18120,8 @@
       "requires": {
         "@repo/types": "*",
         "@repo/typescript-config": "*",
-        "typescript": "^5.7.3"
+        "typescript": "^5.7.3",
+        "zod": "^4.4.2"
       }
     },
     "@repo/media-source-rtmp": {
@@ -18169,6 +18172,7 @@
       "version": "file:packages/plugin-guess-the-tune",
       "requires": {
         "@repo/eslint-config": "*",
+        "@repo/game-logic": "*",
         "@repo/plugin-base": "*",
         "@repo/types": "*",
         "@repo/typescript-config": "*",

--- a/packages/game-logic/package.json
+++ b/packages/game-logic/package.json
@@ -11,18 +11,21 @@
     "./shopping-session-catalog": "./src/shoppingSessionCatalog.ts",
     "./text-effect-stacks": "./src/textEffectStacks.ts",
     "./interface-modifier-stacks": "./src/interfaceModifierStacks.ts",
-    "./chat-buffer-stacks": "./src/chatBufferStacks.ts"
+    "./chat-buffer-stacks": "./src/chatBufferStacks.ts",
+    "./participation-mode": "./src/participationMode.ts"
   },
   "scripts": {
-    "test": "true",
+    "test": "vitest run --reporter=dot",
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
-    "@repo/types": "*"
+    "@repo/types": "*",
+    "zod": "^4.4.2"
   },
   "devDependencies": {
     "@repo/typescript-config": "*",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^4.0.13"
   },
   "license": "ISC"
 }

--- a/packages/game-logic/src/index.ts
+++ b/packages/game-logic/src/index.ts
@@ -22,3 +22,11 @@ export {
 export * from "./shoppingSessionCatalog"
 export { textEffectStyles, type TextEffectStyleObject } from "./textEffectStyles"
 export { shuffleQueueItems } from "./shuffleQueueItems"
+export {
+  PARTICIPATION_MODES,
+  isCompetitiveMode,
+  isInclusiveMode,
+  participationModeFieldMeta,
+  participationModeSchema,
+  type ParticipationMode,
+} from "./participationMode"

--- a/packages/game-logic/src/participationMode.test.ts
+++ b/packages/game-logic/src/participationMode.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest"
+import {
+  PARTICIPATION_MODES,
+  isCompetitiveMode,
+  isInclusiveMode,
+  participationModeSchema,
+} from "./participationMode"
+
+describe("participationMode", () => {
+  it("exports both mode literals", () => {
+    expect(PARTICIPATION_MODES).toEqual(["competitive", "inclusive"])
+  })
+
+  it("defaults schema parse to inclusive", () => {
+    expect(participationModeSchema.parse(undefined)).toBe("inclusive")
+  })
+
+  it("parses explicit modes", () => {
+    expect(participationModeSchema.parse("competitive")).toBe("competitive")
+    expect(participationModeSchema.parse("inclusive")).toBe("inclusive")
+  })
+
+  it("isInclusiveMode is true only for inclusive", () => {
+    expect(isInclusiveMode("inclusive")).toBe(true)
+    expect(isInclusiveMode("competitive")).toBe(false)
+    expect(isInclusiveMode(undefined)).toBe(false)
+    expect(isInclusiveMode(null)).toBe(false)
+  })
+
+  it("isCompetitiveMode is true only for competitive", () => {
+    expect(isCompetitiveMode("competitive")).toBe(true)
+    expect(isCompetitiveMode("inclusive")).toBe(false)
+    expect(isCompetitiveMode(undefined)).toBe(false)
+    expect(isCompetitiveMode(null)).toBe(false)
+  })
+})

--- a/packages/game-logic/src/participationMode.ts
+++ b/packages/game-logic/src/participationMode.ts
@@ -1,0 +1,32 @@
+import { z } from "zod"
+import type { PluginFieldMeta } from "@repo/types"
+
+/** How a plugin gates rewards on user actions. */
+export type ParticipationMode = "competitive" | "inclusive"
+
+export const PARTICIPATION_MODES = ["competitive", "inclusive"] as const satisfies readonly ParticipationMode[]
+
+/** Zod schema for plugin config `mode` fields. Defaults to inclusive (PvG). */
+export const participationModeSchema = z
+  .enum(PARTICIPATION_MODES)
+  .default("inclusive")
+
+/** Admin UI hints for a `mode` config field. Spread and add `showWhen` in plugin schemas. */
+export const participationModeFieldMeta = {
+  type: "enum",
+  label: "Participation mode",
+  description:
+    "Competitive (PvP): first correct guess wins for everyone. Inclusive (PvG): each listener earns independently; guesses are hidden from chat.",
+  enumLabels: {
+    competitive: "Competitive (PvP)",
+    inclusive: "Inclusive (PvG)",
+  },
+} satisfies PluginFieldMeta
+
+export function isInclusiveMode(mode: ParticipationMode | undefined | null): boolean {
+  return mode === "inclusive"
+}
+
+export function isCompetitiveMode(mode: ParticipationMode | undefined | null): boolean {
+  return mode === "competitive"
+}

--- a/packages/plugin-absent-dj/index.test.ts
+++ b/packages/plugin-absent-dj/index.test.ts
@@ -78,6 +78,7 @@ function createMockContext(roomId: string = "test-room"): PluginContext {
     getPluginConfig: vi.fn().mockResolvedValue(null),
     setPluginConfig: vi.fn().mockResolvedValue(undefined),
     getUsersByIds: vi.fn().mockResolvedValue([]),
+    isRoomAdmin: vi.fn().mockResolvedValue(true),
     updatePlaylistTrack: vi.fn().mockResolvedValue(undefined),
     emit: vi.fn().mockResolvedValue(undefined),
     queueSoundEffect: vi.fn().mockResolvedValue(undefined),

--- a/packages/plugin-base/BasePlugin.ts
+++ b/packages/plugin-base/BasePlugin.ts
@@ -1,6 +1,7 @@
 import type { z } from "zod"
 import type {
   ChatMessage,
+  ChatMessageTransformResult,
   GameSessionPluginAPI,
   InventoryItem,
   InventoryPluginAPI,
@@ -346,7 +347,10 @@ export abstract class BasePlugin<TConfig = any> implements Plugin {
    * Optional chat transform. Default: no change (return `null`).
    * @see `PluginRegistry.transformChatMessage`
    */
-  async transformChatMessage(_roomId: string, _message: ChatMessage): Promise<ChatMessage | null> {
+  async transformChatMessage(
+    _roomId: string,
+    _message: ChatMessage,
+  ): Promise<ChatMessageTransformResult> {
     return null
   }
 

--- a/packages/plugin-base/index.test.ts
+++ b/packages/plugin-base/index.test.ts
@@ -92,6 +92,7 @@ function createMockContext(roomId: string = "test-room"): PluginContext {
     getReactions: vi.fn().mockResolvedValue([]),
     getUsers: vi.fn().mockResolvedValue([]),
     getUsersByIds: vi.fn().mockResolvedValue([]),
+    isRoomAdmin: vi.fn().mockResolvedValue(true),
     skipTrack: vi.fn().mockResolvedValue(undefined),
     sendSystemMessage: vi.fn().mockResolvedValue(undefined),
     sendUserSystemMessage: vi.fn().mockResolvedValue(undefined),

--- a/packages/plugin-guess-the-tune/index.test.ts
+++ b/packages/plugin-guess-the-tune/index.test.ts
@@ -17,6 +17,10 @@ function roundKey(stable: string): string {
   return `round:${stable}`
 }
 
+function roundUserKey(stable: string, userId: string): string {
+  return `roundUser:${stable}:${userId}`
+}
+
 function createNowPlaying(overrides?: {
   title?: string
   artist?: string
@@ -53,11 +57,14 @@ function createChatMessage(content: string, userId: string, username?: string): 
 /** In-memory hash storage for round reveal state. */
 function createInMemoryStorage(): PluginStorage & {
   hashes: Map<string, Record<string, string>>
+  zsets: Map<string, Map<string, number>>
 } {
   const hashes = new Map<string, Record<string, string>>()
+  const zsets = new Map<string, Map<string, number>>()
 
   return {
     hashes,
+    zsets,
     get: vi.fn().mockResolvedValue(null),
     set: vi.fn().mockResolvedValue(undefined),
     inc: vi.fn().mockResolvedValue(1),
@@ -68,10 +75,20 @@ function createInMemoryStorage(): PluginStorage & {
     exists: vi.fn().mockResolvedValue(false),
     mget: vi.fn().mockResolvedValue([]),
     pipeline: vi.fn().mockResolvedValue([]),
-    zadd: vi.fn().mockResolvedValue(undefined),
+    zadd: vi.fn(async (key: string, score: number, value: string) => {
+      const z = zsets.get(key) ?? new Map<string, number>()
+      z.set(value, score)
+      zsets.set(key, z)
+    }),
     zrem: vi.fn().mockResolvedValue(undefined),
     zincrby: vi.fn().mockResolvedValue(0),
-    zrange: vi.fn().mockResolvedValue([]),
+    zrange: vi.fn(async (key: string, start: number, stop: number) => {
+      const z = zsets.get(key)
+      if (!z) return []
+      const entries = [...z.entries()].sort((a, b) => a[1] - b[1]).map(([member]) => member)
+      const end = stop < 0 ? entries.length + stop + 1 : stop + 1
+      return entries.slice(start, end)
+    }),
     zrangeWithScores: vi.fn().mockResolvedValue([]),
     zrangebyscore: vi.fn().mockResolvedValue([]),
     zremrangebyscore: vi.fn().mockResolvedValue(undefined),
@@ -106,6 +123,7 @@ function createMockContext(roomId = "room1"): PluginContext & {
     getReactions: vi.fn().mockResolvedValue([]),
     getUsers: vi.fn().mockResolvedValue([]),
     getUsersByIds: vi.fn().mockResolvedValue([]),
+    isRoomAdmin: vi.fn().mockResolvedValue(true),
     skipTrack: vi.fn().mockResolvedValue(undefined),
     sendSystemMessage: vi.fn().mockResolvedValue(undefined),
     sendUserSystemMessage: vi.fn().mockResolvedValue(undefined),
@@ -309,6 +327,7 @@ describe("propsInPlay", () => {
 describe("GuessTheTunePlugin onMessageReceived", () => {
   const enabledConfig: Partial<GuessTheTuneConfig> = {
     enabled: true,
+    mode: "competitive",
     soundEffectOnMatch: false,
     fuzzyThreshold: 0.35,
   }
@@ -429,5 +448,256 @@ describe("GuessTheTunePlugin onMessageReceived", () => {
     expect(revealed["revealed:album"]).toBeUndefined()
     expect(revealed["revealed:artist"]).toBeUndefined()
     expect(vi.mocked(mockContext.storage.zincrby)).not.toHaveBeenCalled()
+  })
+})
+
+describe("GuessTheTunePlugin transformChatMessage (inclusive mode)", () => {
+  const inclusiveConfig: Partial<GuessTheTuneConfig> = {
+    enabled: true,
+    mode: "inclusive",
+    soundEffectOnMatch: false,
+    fuzzyThreshold: 0.35,
+  }
+
+  let plugin: GuessTheTunePlugin
+  let mockContext: ReturnType<typeof createMockContext>
+
+  beforeEach(() => {
+    plugin = new GuessTheTunePlugin(inclusiveConfig)
+    mockContext = createMockContext()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-01-01T12:00:00.000Z"))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it("two users guessing the same prop both earn points and get per-user reveals", async () => {
+    const np = createNowPlaying({
+      title: "Yesterday",
+      artist: "The Beatles",
+      album: "Help!",
+    })
+    const stable = queueItemStableKey(np)
+    await setupActiveRound(mockContext, np)
+    await plugin.register(mockContext)
+
+    const first = await plugin.transformChatMessage!(
+      mockContext.roomId,
+      createChatMessage("yesterday", "u1", "Alice"),
+    )
+    expect(first).toEqual({ drop: true, reason: "guess-the-tune-match" })
+
+    const u1Revealed = await mockContext.storage.hgetall(roundUserKey(stable, "u1"))
+    expect(u1Revealed["revealed:title"]).toBeTruthy()
+    expect(await mockContext.storage.hgetall(roundKey(stable))).not.toHaveProperty("revealed:title")
+
+    const zincrbyAfterFirst = vi.mocked(mockContext.storage.zincrby).mock.calls.length
+
+    const second = await plugin.transformChatMessage!(
+      mockContext.roomId,
+      createChatMessage("yesterday", "u2", "Bob"),
+    )
+    expect(second).toEqual({ drop: true, reason: "guess-the-tune-match" })
+
+    const u2Revealed = await mockContext.storage.hgetall(roundUserKey(stable, "u2"))
+    expect(u2Revealed["revealed:title"]).toBeTruthy()
+    expect(vi.mocked(mockContext.storage.zincrby).mock.calls.length).toBeGreaterThan(
+      zincrbyAfterFirst,
+    )
+    expect(vi.mocked(mockContext.api.sendSystemMessage).mock.calls.length).toBe(2)
+  })
+
+  it("does not drop chat when the message does not match", async () => {
+    const np = createNowPlaying()
+    await setupActiveRound(mockContext, np)
+    await plugin.register(mockContext)
+
+    const result = await plugin.transformChatMessage!(
+      mockContext.roomId,
+      createChatMessage("hello world", "u1"),
+    )
+    expect(result).toBeNull()
+    expect(vi.mocked(mockContext.storage.zincrby)).not.toHaveBeenCalled()
+  })
+
+  it("MESSAGE_RECEIVED handler is inactive in inclusive mode", async () => {
+    const np = createNowPlaying({ title: "Yesterday", artist: "The Beatles", album: "Help!" })
+    await setupActiveRound(mockContext, np)
+    await plugin.register(mockContext)
+
+    await emitMessage(mockContext, createChatMessage("yesterday", "u1"))
+
+    expect(vi.mocked(mockContext.storage.zincrby)).not.toHaveBeenCalled()
+  })
+})
+
+describe("GuessTheTunePlugin augmentNowPlaying userReveals (inclusive mode)", () => {
+  const inclusiveConfig: Partial<GuessTheTuneConfig> = {
+    enabled: true,
+    mode: "inclusive",
+    soundEffectOnMatch: false,
+    fuzzyThreshold: 0.35,
+  }
+
+  let plugin: GuessTheTunePlugin
+  let mockContext: ReturnType<typeof createMockContext>
+
+  beforeEach(() => {
+    plugin = new GuessTheTunePlugin(inclusiveConfig)
+    mockContext = createMockContext()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-01-01T12:00:00.000Z"))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it("includes per-user reveals in augmentation while room-level slots stay obscured", async () => {
+    const np = createNowPlaying({
+      title: "Yesterday",
+      artist: "The Beatles",
+      album: "Help!",
+    })
+    const stable = queueItemStableKey(np)
+    await setupActiveRound(mockContext, np)
+    await plugin.register(mockContext)
+
+    await plugin.transformChatMessage!(
+      mockContext.roomId,
+      createChatMessage("yesterday", "u1", "Alice"),
+    )
+    await plugin.transformChatMessage!(
+      mockContext.roomId,
+      createChatMessage("yesterday", "u2", "Bob"),
+    )
+
+    const aug = await plugin.augmentNowPlaying(np)
+
+    expect(aug.elementProps?.title?.obscured).toBe(true)
+    expect(aug.userReveals?.u1?.title).toMatchObject({
+      userId: "u1",
+      username: "Alice",
+    })
+    expect(aug.userReveals?.u2?.title).toMatchObject({
+      userId: "u2",
+      username: "Bob",
+    })
+    expect(await mockContext.storage.hgetall(roundKey(stable))).not.toHaveProperty("revealed:title")
+  })
+
+  it("omits userReveals in competitive mode", async () => {
+    const competitivePlugin = new GuessTheTunePlugin({
+      enabled: true,
+      mode: "competitive",
+      soundEffectOnMatch: false,
+      fuzzyThreshold: 0.35,
+    })
+    const np = createNowPlaying({ title: "Yesterday", artist: "The Beatles", album: "Help!" })
+    await setupActiveRound(mockContext, np)
+    await competitivePlugin.register(mockContext)
+
+    await emitMessage(mockContext, createChatMessage("yesterday", "u1", "Alice"))
+
+    const aug = await competitivePlugin.augmentNowPlaying(np)
+
+    expect(aug.elementProps?.title?.obscured).toBe(false)
+    expect(aug.userReveals).toBeUndefined()
+  })
+})
+
+describe("GuessTheTunePlugin admin reveal actions", () => {
+  const enabledConfig: Partial<GuessTheTuneConfig> = {
+    enabled: true,
+    mode: "inclusive",
+    soundEffectOnMatch: false,
+    fuzzyThreshold: 0.35,
+  }
+
+  let plugin: GuessTheTunePlugin
+  let mockContext: ReturnType<typeof createMockContext>
+
+  beforeEach(() => {
+    plugin = new GuessTheTunePlugin(enabledConfig)
+    mockContext = createMockContext()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-01-01T12:00:00.000Z"))
+    vi.mocked(mockContext.api.isRoomAdmin).mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it("rejects non-admin initiators", async () => {
+    vi.mocked(mockContext.api.isRoomAdmin).mockResolvedValue(false)
+    const np = createNowPlaying({ title: "Yesterday", artist: "The Beatles", album: "Help!" })
+    await setupActiveRound(mockContext, np)
+    await plugin.register(mockContext)
+
+    const result = await plugin.executeAction("revealTitle", {
+      userId: "u1",
+      username: "Bob",
+    })
+
+    expect(result).toEqual({ success: false, message: "Admin required" })
+    expect(vi.mocked(mockContext.api.sendSystemMessage)).not.toHaveBeenCalled()
+  })
+
+  it("admin reveal is global in inclusive mode", async () => {
+    const np = createNowPlaying({ title: "Yesterday", artist: "The Beatles", album: "Help!" })
+    const stable = queueItemStableKey(np)
+    await setupActiveRound(mockContext, np)
+    await plugin.register(mockContext)
+
+    await plugin.transformChatMessage!(
+      mockContext.roomId,
+      createChatMessage("yesterday", "u1", "Alice"),
+    )
+
+    const result = await plugin.executeAction("revealArtist", {
+      userId: "admin1",
+      username: "Admin",
+    })
+
+    expect(result.success).toBe(true)
+    const globalRound = await mockContext.storage.hgetall(roundKey(stable))
+    expect(globalRound["revealed:artist"]).toBeTruthy()
+    expect(JSON.parse(globalRound["revealed:artist"]!).source).toBe("admin")
+
+    const aug = await plugin.augmentNowPlaying(np)
+    expect(aug.elementProps?.artist?.obscured).toBe(false)
+    expect(aug.userReveals?.u1?.title).toBeTruthy()
+  })
+
+  it("admin reveal is global in competitive mode", async () => {
+    const competitivePlugin = new GuessTheTunePlugin({
+      enabled: true,
+      mode: "competitive",
+      soundEffectOnMatch: false,
+      fuzzyThreshold: 0.35,
+    })
+    const np = createNowPlaying({ title: "Yesterday", artist: "The Beatles", album: "Help!" })
+    const stable = queueItemStableKey(np)
+    await setupActiveRound(mockContext, np)
+    await competitivePlugin.register(mockContext)
+
+    const result = await competitivePlugin.executeAction("revealTitle", {
+      userId: "admin1",
+      username: "Admin",
+    })
+
+    expect(result.success).toBe(true)
+    const globalRound = await mockContext.storage.hgetall(roundKey(stable))
+    expect(globalRound["revealed:title"]).toBeTruthy()
+
+    const aug = await competitivePlugin.augmentNowPlaying(np)
+    expect(aug.elementProps?.title?.obscured).toBe(false)
+    expect(aug.userReveals).toBeUndefined()
   })
 })

--- a/packages/plugin-guess-the-tune/index.ts
+++ b/packages/plugin-guess-the-tune/index.ts
@@ -6,16 +6,19 @@ import type {
   PluginComponentSchema,
   SystemEventPayload,
   ChatMessage,
+  ChatMessageTransformResult,
   PluginAugmentationData,
   PluginElementKey,
   PluginElementProps,
   PluginObscureBypassRole,
   PluginTextElementKey,
+  PluginUserReveals,
   QueueItem,
   RoomExportData,
   PluginExportAugmentation,
 } from "@repo/types"
 import { queueItemStableKey } from "@repo/types"
+import { isInclusiveMode, type ParticipationMode } from "@repo/game-logic"
 import { BasePlugin } from "@repo/plugin-base"
 import { interpolateTemplate } from "@repo/utils"
 import packageJson from "./package.json"
@@ -32,12 +35,23 @@ export type { GuessTheTuneConfig } from "./types"
 export { guessTheTuneConfigSchema, defaultGuessTheTuneConfig } from "./types"
 
 const USER_SCORES_KEY = "user-scores"
+const USER_REVEALS_CAP = 200
 
 function roundKey(stable: string): string {
   return `round:${stable}`
 }
 
+function roundUserKey(stable: string, userId: string): string {
+  return `roundUser:${stable}:${userId}`
+}
+
+function roundUserIndexKey(stable: string): string {
+  return `roundUserIndex:${stable}`
+}
+
 const TEXT_KEYS = ["title", "artist", "album"] as const satisfies readonly PluginTextElementKey[]
+
+type RevealByPayload = NonNullable<PluginElementProps["revealedBy"]>
 
 export interface GuessTheTuneComponentState extends Record<string, unknown> {
   usersLeaderboard: { score: number; value: string; username: string }[]
@@ -50,6 +64,8 @@ export interface GuessTheTuneEvents {
     username?: string
     points: number
     multiplier: number
+    mode: ParticipationMode
+    revealedBy: RevealByPayload
     usersLeaderboard: { score: number; value: string; username: string }[]
   }
   LEADERBOARD_RESET: {
@@ -91,8 +107,6 @@ export function propsInPlay(
   if (config.matchAlbum && targets.album.trim()) props.push("album")
   return props
 }
-
-type RevealByPayload = NonNullable<PluginElementProps["revealedBy"]>
 
 export class GuessTheTunePlugin extends BasePlugin<GuessTheTuneConfig> {
   name = "guess-the-tune"
@@ -141,6 +155,7 @@ export class GuessTheTunePlugin extends BasePlugin<GuessTheTuneConfig> {
 
     const stable = queueItemStableKey(data.track)
     const rk = roundKey(stable)
+    await this.clearRoundUserState(stable)
     await this.context.storage.del(rk)
     await this.context.storage.hset(rk, "startedAt", String(Date.now()))
 
@@ -150,20 +165,41 @@ export class GuessTheTunePlugin extends BasePlugin<GuessTheTuneConfig> {
     }
   }
 
+  async transformChatMessage(
+    _roomId: string,
+    message: ChatMessage,
+  ): Promise<ChatMessageTransformResult> {
+    const config = await this.getConfig()
+    if (!config?.enabled || !isInclusiveMode(config.mode)) return null
+
+    const awarded = await this.handleInclusiveGuess(message, config)
+    if (awarded) {
+      return { drop: true, reason: "guess-the-tune-match" }
+    }
+    return null
+  }
+
   private async onMessageReceived(data: SystemEventPayload<"MESSAGE_RECEIVED">): Promise<void> {
     const config = await this.getConfig()
     if (!config?.enabled || !this.context) return
+    if (isInclusiveMode(config.mode)) return
 
     const { message } = data
     if (this.isSystemMessage(message)) return
 
+    await this.handleCompetitiveGuess(message, config)
+  }
+
+  private async handleCompetitiveGuess(
+    message: ChatMessage,
+    config: GuessTheTuneConfig,
+  ): Promise<void> {
+    if (!this.context) return
+
     const np = await this.context.api.getNowPlaying(this.context.roomId)
     if (!np?.track) return
 
-    if (
-      config.ignoreOwnQueueSubmissions &&
-      np.addedBy?.userId === message.user.userId
-    ) {
+    if (config.ignoreOwnQueueSubmissions && np.addedBy?.userId === message.user.userId) {
       return
     }
 
@@ -178,26 +214,16 @@ export class GuessTheTunePlugin extends BasePlugin<GuessTheTuneConfig> {
 
     const propsToTry = propsInPlay(config, targets)
 
-    const basePoints: Record<GuessProperty, number> = {
-      title: config.pointsTitle,
-      artist: config.pointsArtist,
-      album: config.pointsAlbum,
-    }
-
-    let needsMetaRefresh = false
-
     const matches: Partial<Record<GuessProperty, boolean>> = {}
     for (const prop of propsToTry) {
-      matches[prop] = messageMatchesTarget(
-        message.content,
-        targets[prop],
-        config.fuzzyThreshold,
-      )
+      matches[prop] = messageMatchesTarget(message.content, targets[prop], config.fuzzyThreshold)
     }
 
     if (propsToTry.some((p) => matches[p] && revealedAll[`revealed:${p}`])) {
       return
     }
+
+    let needsMetaRefresh = false
 
     for (const prop of propsToTry) {
       const field = `revealed:${prop}`
@@ -208,59 +234,189 @@ export class GuessTheTunePlugin extends BasePlugin<GuessTheTuneConfig> {
         userId: message.user.userId,
         username: message.user.username ?? "",
         at: Date.now(),
+        source: "chat",
       }
 
       const didSet = await this.revealRoundProperty(rk, prop, revealedBy)
       if (!didSet) return
       revealedAll[field] = JSON.stringify(revealedBy)
 
-      const elapsed = Date.now() - startedAt
-      const mult = elapsed <= config.speedMultiplierWindowSec * 1000 ? config.speedMultiplier : 1
-      const points = Math.floor(basePoints[prop] * mult)
-
-      await this.context.storage.zincrby(USER_SCORES_KEY, points, message.user.userId)
-
-      await this.context.game.addScore(message.user.userId, "score", points, "guess-the-tune")
-      await this.context.game.addScore(message.user.userId, "coin", points, "guess-the-tune")
-
-      const multiplierSuffix = mult > 1 ? ` (${mult}× speed bonus)` : ""
-
-      const body = interpolateTemplate(config.messageTemplate ?? "", {
-        username: message.user.username ?? message.user.userId,
-        propertyLabel: propertyLabel(prop),
-        points: String(points),
-        multiplierSuffix,
-      })
-
-      await this.context.api.sendSystemMessage(this.context.roomId, body)
-
-      const state = await this.getComponentState()
-
-      await this.emit<GuessTheTuneEvents["PROPERTY_REVEALED"]>("PROPERTY_REVEALED", {
-        property: prop,
+      needsMetaRefresh = await this.awardCorrectGuess({
+        prop,
         userId: message.user.userId,
         username: message.user.username ?? undefined,
-        points,
-        multiplier: mult,
-        usersLeaderboard: state.usersLeaderboard,
+        config,
+        startedAt,
+        mode: "competitive",
+        revealedBy,
       })
-
-      if (config.soundEffectOnMatch) {
-        await this.context.api.queueSoundEffect({
-          url: config.soundEffectOnMatchUrl ?? "",
-          volume: 0.3,
-        })
-      }
-
-      needsMetaRefresh = true
     }
 
     if (needsMetaRefresh) {
-      const fresh = await this.context.api.getNowPlaying(this.context.roomId)
-      if (fresh) {
-        await this.context.api.updatePlaylistTrack(this.context.roomId, fresh)
+      await this.refreshNowPlayingAugmentation()
+    }
+  }
+
+  /** Inclusive (PvG) path — runs in transformChatMessage before broadcast. Returns whether any prop was awarded. */
+  private async handleInclusiveGuess(
+    message: ChatMessage,
+    config: GuessTheTuneConfig,
+  ): Promise<boolean> {
+    if (!this.context) return false
+    if (this.isSystemMessage(message)) return false
+
+    const np = await this.context.api.getNowPlaying(this.context.roomId)
+    if (!np?.track) return false
+
+    if (config.ignoreOwnQueueSubmissions && np.addedBy?.userId === message.user.userId) {
+      return false
+    }
+
+    const stable = queueItemStableKey(np)
+    const rk = roundKey(stable)
+    const userRk = roundUserKey(stable, message.user.userId)
+    const startedAtStr = await this.context.storage.hget(rk, "startedAt")
+    if (!startedAtStr) return false
+
+    const startedAt = Number(startedAtStr)
+    const targets = trackStrings(np.track)
+    const globalRevealed: Record<string, string> = { ...(await this.context.storage.hgetall(rk)) }
+    const userRevealed: Record<string, string> = { ...(await this.context.storage.hgetall(userRk)) }
+
+    const propsToTry = propsInPlay(config, targets)
+
+    const matches: Partial<Record<GuessProperty, boolean>> = {}
+    for (const prop of propsToTry) {
+      matches[prop] = messageMatchesTarget(message.content, targets[prop], config.fuzzyThreshold)
+    }
+
+    if (propsToTry.some((p) => matches[p] && globalRevealed[`revealed:${p}`])) {
+      return false
+    }
+
+    let anyAwarded = false
+    let needsMetaRefresh = false
+
+    for (const prop of propsToTry) {
+      if (globalRevealed[`revealed:${prop}`]) continue
+      if (userRevealed[`revealed:${prop}`]) continue
+      if (!matches[prop]) continue
+
+      const revealedBy: RevealByPayload = {
+        userId: message.user.userId,
+        username: message.user.username ?? "",
+        at: Date.now(),
+        source: "chat",
+      }
+
+      const didSet = await this.revealUserRoundProperty(
+        stable,
+        message.user.userId,
+        prop,
+        revealedBy,
+      )
+      if (!didSet) continue
+      userRevealed[`revealed:${prop}`] = JSON.stringify(revealedBy)
+
+      const awarded = await this.awardCorrectGuess({
+        prop,
+        userId: message.user.userId,
+        username: message.user.username ?? undefined,
+        config,
+        startedAt,
+        mode: "inclusive",
+        revealedBy,
+      })
+      if (awarded) {
+        anyAwarded = true
+        needsMetaRefresh = true
       }
     }
+
+    if (needsMetaRefresh) {
+      await this.refreshNowPlayingAugmentation()
+    }
+
+    return anyAwarded
+  }
+
+  private async awardCorrectGuess(params: {
+    prop: GuessProperty
+    userId: string
+    username?: string
+    config: GuessTheTuneConfig
+    startedAt: number
+    mode: ParticipationMode
+    revealedBy: RevealByPayload
+  }): Promise<boolean> {
+    if (!this.context) return false
+
+    const { prop, userId, username, config, startedAt, mode, revealedBy } = params
+
+    const basePoints: Record<GuessProperty, number> = {
+      title: config.pointsTitle,
+      artist: config.pointsArtist,
+      album: config.pointsAlbum,
+    }
+
+    const elapsed = Date.now() - startedAt
+    const mult = elapsed <= config.speedMultiplierWindowSec * 1000 ? config.speedMultiplier : 1
+    const points = Math.floor(basePoints[prop] * mult)
+
+    await this.context.storage.zincrby(USER_SCORES_KEY, points, userId)
+    await this.context.game.addScore(userId, "score", points, "guess-the-tune")
+    await this.context.game.addScore(userId, "coin", points, "guess-the-tune")
+
+    const multiplierSuffix = mult > 1 ? ` (${mult}× speed bonus)` : ""
+
+    const body = interpolateTemplate(config.messageTemplate ?? "", {
+      username: username ?? userId,
+      propertyLabel: propertyLabel(prop),
+      points: String(points),
+      multiplierSuffix,
+    })
+
+    await this.context.api.sendSystemMessage(this.context.roomId, body)
+
+    const state = await this.getComponentState()
+
+    await this.emit<GuessTheTuneEvents["PROPERTY_REVEALED"]>("PROPERTY_REVEALED", {
+      property: prop,
+      userId,
+      username,
+      points,
+      multiplier: mult,
+      mode,
+      revealedBy,
+      usersLeaderboard: state.usersLeaderboard,
+    })
+
+    if (config.soundEffectOnMatch) {
+      await this.context.api.queueSoundEffect({
+        url: config.soundEffectOnMatchUrl ?? "",
+        volume: 0.3,
+      })
+    }
+
+    return true
+  }
+
+  private async refreshNowPlayingAugmentation(): Promise<void> {
+    if (!this.context) return
+    const fresh = await this.context.api.getNowPlaying(this.context.roomId)
+    if (fresh) {
+      await this.context.api.updatePlaylistTrack(this.context.roomId, fresh)
+    }
+  }
+
+  private async clearRoundUserState(stable: string): Promise<void> {
+    if (!this.context) return
+    const indexKey = roundUserIndexKey(stable)
+    const userIds = await this.context.storage.zrange(indexKey, 0, -1)
+    for (const userId of userIds) {
+      await this.context.storage.del(roundUserKey(stable, userId))
+    }
+    await this.context.storage.del(indexKey)
   }
 
   async augmentNowPlaying(item: QueueItem): Promise<PluginAugmentationData> {
@@ -331,6 +487,22 @@ export class GuessTheTunePlugin extends BasePlugin<GuessTheTuneConfig> {
     return this.context.storage.hsetnx(rk, field, JSON.stringify(revealedBy))
   }
 
+  private async revealUserRoundProperty(
+    stable: string,
+    userId: string,
+    prop: GuessProperty,
+    revealedBy: RevealByPayload,
+  ): Promise<boolean> {
+    if (!this.context) return false
+    const userRk = roundUserKey(stable, userId)
+    const field = `revealed:${prop}`
+    const didSet = await this.context.storage.hsetnx(userRk, field, JSON.stringify(revealedBy))
+    if (didSet) {
+      await this.context.storage.zadd(roundUserIndexKey(stable), revealedBy.at, userId)
+    }
+    return didSet
+  }
+
   private resolveAdminRevealLabel(initiator?: PluginActionInitiator): string {
     const username = initiator?.username?.trim()
     if (username) return username
@@ -351,10 +523,33 @@ export class GuessTheTunePlugin extends BasePlugin<GuessTheTuneConfig> {
     }
   }
 
+  private async requireRoomAdmin(
+    initiator?: PluginActionInitiator,
+  ): Promise<
+    | { ok: true }
+    | { ok: false; result: { success: false; message: string } }
+  > {
+    if (!this.context) {
+      return { ok: false, result: { success: false, message: "Plugin not initialized" } }
+    }
+    const userId = initiator?.userId?.trim()
+    if (!userId) {
+      return { ok: false, result: { success: false, message: "Admin required" } }
+    }
+    const isAdmin = await this.context.api.isRoomAdmin(this.context.roomId, userId)
+    if (!isAdmin) {
+      return { ok: false, result: { success: false, message: "Admin required" } }
+    }
+    return { ok: true }
+  }
+
   private async adminRevealProperty(
     prop: GuessProperty,
     initiator?: PluginActionInitiator,
   ): Promise<{ success: boolean; message?: string }> {
+    const adminCheck = await this.requireRoomAdmin(initiator)
+    if (!adminCheck.ok) return adminCheck.result
+
     if (!this.context) {
       return { success: false, message: "Plugin not initialized" }
     }
@@ -413,6 +608,9 @@ export class GuessTheTunePlugin extends BasePlugin<GuessTheTuneConfig> {
   private async adminRevealAll(
     initiator?: PluginActionInitiator,
   ): Promise<{ success: boolean; message?: string }> {
+    const adminCheck = await this.requireRoomAdmin(initiator)
+    if (!adminCheck.ok) return adminCheck.result
+
     if (!this.context) {
       return { success: false, message: "Plugin not initialized" }
     }
@@ -566,8 +764,69 @@ export class GuessTheTunePlugin extends BasePlugin<GuessTheTuneConfig> {
       obscureBypassRoles: bypassRoles,
     }
 
-    return { elementProps }
+    const result: PluginAugmentationData = { elementProps }
+
+    if (isInclusiveMode(config.mode)) {
+      const userReveals = await this.loadUserRevealsForRound(stable)
+      if (userReveals && Object.keys(userReveals).length > 0) {
+        result.userReveals = userReveals
+      }
+    }
+
+    return result
   }
+
+  private async loadUserRevealsForRound(stable: string): Promise<PluginUserReveals | undefined> {
+    if (!this.context) return undefined
+
+    const userIds = await this.context.storage.zrange(roundUserIndexKey(stable), 0, -1)
+    if (userIds.length === 0) return undefined
+
+    const entries: Array<{
+      userId: string
+      reveals: PluginUserReveals[string]
+      latestAt: number
+    }> = []
+
+    for (const userId of userIds) {
+      const raw = await this.context.storage.hgetall(roundUserKey(stable, userId))
+      const reveals = parseUserRevealFields(raw)
+      if (Object.keys(reveals).length === 0) continue
+
+      const latestAt = Math.max(...Object.values(reveals).map((r) => r?.at ?? 0), 0)
+      entries.push({ userId, reveals, latestAt })
+    }
+
+    if (entries.length === 0) return undefined
+
+    entries.sort((a, b) => b.latestAt - a.latestAt)
+    const capped = entries.slice(0, USER_REVEALS_CAP)
+
+    const userReveals: PluginUserReveals = {}
+    for (const { userId, reveals } of capped) {
+      userReveals[userId] = reveals
+    }
+    return userReveals
+  }
+}
+
+function parseUserRevealFields(raw: Record<string, string>): PluginUserReveals[string] {
+  const reveals: PluginUserReveals[string] = {}
+
+  for (const key of TEXT_KEYS) {
+    const rev = raw[`revealed:${key}`]
+    if (!rev) continue
+    try {
+      const parsed = JSON.parse(rev) as PluginElementProps["revealedBy"]
+      if (parsed?.userId != null) {
+        reveals[key] = parsed
+      }
+    } catch {
+      // ignore malformed entries
+    }
+  }
+
+  return reveals
 }
 
 export function createGuessTheTunePlugin(configOverrides?: Partial<GuessTheTuneConfig>): Plugin {

--- a/packages/plugin-guess-the-tune/matching.ts
+++ b/packages/plugin-guess-the-tune/matching.ts
@@ -192,7 +192,10 @@ function tokenMatchesTargetWord(
 ): boolean {
   if (!candidate.length || !targetWord.length) return false
   if (candidate.length === 1 && targetWord.length < 3) return false
-  if (treatAsSingleWordTitle && candidate.length < minCandidateLengthForSingleWordTarget(targetWord)) {
+  if (
+    treatAsSingleWordTitle &&
+    candidate.length < minCandidateLengthForSingleWordTarget(targetWord)
+  ) {
     return false
   }
 

--- a/packages/plugin-guess-the-tune/package.json
+++ b/packages/plugin-guess-the-tune/package.json
@@ -21,6 +21,7 @@
     "vitest": "^4.0.13"
   },
   "dependencies": {
+    "@repo/game-logic": "*",
     "@repo/plugin-base": "*",
     "@repo/types": "*",
     "@repo/utils": "*",

--- a/packages/plugin-guess-the-tune/schema.ts
+++ b/packages/plugin-guess-the-tune/schema.ts
@@ -1,10 +1,91 @@
 import { z } from "zod"
+import { participationModeFieldMeta } from "@repo/game-logic"
 import type { PluginConfigSchema, PluginComponentSchema, PluginActionElement } from "@repo/types"
 import { guessTheTuneConfigSchema } from "./types"
+
+const REVEAL_TITLE_CONFIRM =
+  "Show the real track title in Now Playing for all listeners? This does not award points."
+const REVEAL_ARTIST_CONFIRM =
+  "Show the real artist name in Now Playing for all listeners? This does not award points."
+const REVEAL_ALBUM_CONFIRM =
+  "Show the real album title in Now Playing for all listeners? This does not award points."
+const REVEAL_ALL_CONFIRM =
+  "Reveal every obscured title, artist, and album field that applies to the current track? No points are awarded."
 
 export function getComponentSchema(): PluginComponentSchema {
   return {
     components: [
+      {
+        id: "guess-tune-reveal-title",
+        type: "button",
+        area: "nowPlayingInfo",
+        label: "Reveal title",
+        variant: "solid",
+        size: "xs",
+        colorPalette: "action",
+        action: "revealTitle",
+        adminOnly: true,
+        confirmMessage: REVEAL_TITLE_CONFIRM,
+        confirmText: "Reveal title",
+        showWhen: [
+          { field: "enabled", value: true },
+          { field: "matchTitle", value: true },
+          { field: "item.titleObscured", value: true },
+        ],
+      },
+      {
+        id: "guess-tune-reveal-artist",
+        type: "button",
+        area: "nowPlayingInfo",
+        label: "Reveal artist",
+        variant: "solid",
+        size: "xs",
+        colorPalette: "action",
+        action: "revealArtist",
+        adminOnly: true,
+        confirmMessage: REVEAL_ARTIST_CONFIRM,
+        confirmText: "Reveal artist",
+        showWhen: [
+          { field: "enabled", value: true },
+          { field: "matchArtist", value: true },
+          { field: "item.artistObscured", value: true },
+        ],
+      },
+      {
+        id: "guess-tune-reveal-album",
+        type: "button",
+        area: "nowPlayingInfo",
+        label: "Reveal album",
+        variant: "solid",
+        size: "xs",
+        colorPalette: "action",
+        action: "revealAlbum",
+        adminOnly: true,
+        confirmMessage: REVEAL_ALBUM_CONFIRM,
+        confirmText: "Reveal album",
+        showWhen: [
+          { field: "enabled", value: true },
+          { field: "matchAlbum", value: true },
+          { field: "item.albumObscured", value: true },
+        ],
+      },
+      {
+        id: "guess-tune-reveal-all",
+        type: "button",
+        area: "nowPlayingInfo",
+        label: "Reveal all",
+        variant: "solid",
+        size: "xs",
+        colorPalette: "action",
+        action: "revealAll",
+        adminOnly: true,
+        confirmMessage: REVEAL_ALL_CONFIRM,
+        confirmText: "Reveal all",
+        showWhen: [
+          { field: "enabled", value: true },
+          { field: "item.anyObscured", value: true },
+        ],
+      },
       {
         id: "guess-tune-leaderboard-button",
         type: "button",
@@ -60,8 +141,7 @@ export function getConfigSchema(): PluginConfigSchema {
     action: "revealTitle",
     label: "Reveal track title for everyone",
     variant: "outline",
-    confirmMessage:
-      "Show the real track title in Now Playing for all listeners? This does not award points.",
+    confirmMessage: REVEAL_TITLE_CONFIRM,
     confirmText: "Reveal title",
     showWhen: { field: "enabled", value: true },
   } satisfies PluginActionElement
@@ -71,8 +151,7 @@ export function getConfigSchema(): PluginConfigSchema {
     action: "revealArtist",
     label: "Reveal artist for everyone",
     variant: "outline",
-    confirmMessage:
-      "Show the real artist name in Now Playing for all listeners? This does not award points.",
+    confirmMessage: REVEAL_ARTIST_CONFIRM,
     confirmText: "Reveal artist",
     showWhen: { field: "enabled", value: true },
   } satisfies PluginActionElement
@@ -82,8 +161,7 @@ export function getConfigSchema(): PluginConfigSchema {
     action: "revealAlbum",
     label: "Reveal album for everyone",
     variant: "outline",
-    confirmMessage:
-      "Show the real album title in Now Playing for all listeners? This does not award points.",
+    confirmMessage: REVEAL_ALBUM_CONFIRM,
     confirmText: "Reveal album",
     showWhen: { field: "enabled", value: true },
   } satisfies PluginActionElement
@@ -93,8 +171,7 @@ export function getConfigSchema(): PluginConfigSchema {
     action: "revealAll",
     label: "Reveal all obscured fields",
     variant: "outline",
-    confirmMessage:
-      "Reveal every obscured title, artist, and album field that applies to the current track? No points are awarded.",
+    confirmMessage: REVEAL_ALL_CONFIRM,
     confirmText: "Reveal all",
     showWhen: { field: "enabled", value: true },
   } satisfies PluginActionElement
@@ -104,8 +181,7 @@ export function getConfigSchema(): PluginConfigSchema {
     action: "resetLeaderboard",
     label: "Reset leaderboard",
     variant: "destructive",
-    confirmMessage:
-      "Reset all Guess the Tune scores? This cannot be undone.",
+    confirmMessage: "Reset all Guess the Tune scores? This cannot be undone.",
     confirmText: "Reset leaderboard",
     showWhen: { field: "enabled", value: true },
   } satisfies PluginActionElement
@@ -121,6 +197,7 @@ export function getConfigSchema(): PluginConfigSchema {
         variant: "info",
       },
       "enabled",
+      "mode",
       "matchTitle",
       "matchArtist",
       "matchAlbum",
@@ -146,7 +223,12 @@ export function getConfigSchema(): PluginConfigSchema {
       enabled: {
         type: "boolean",
         label: "Enable Guess the Tune",
-        description: "When enabled, now playing fields can be obscured and chat guesses score points.",
+        description:
+          "When enabled, now playing fields can be obscured and chat guesses score points.",
+      },
+      mode: {
+        ...participationModeFieldMeta,
+        showWhen: { field: "enabled", value: true },
       },
       matchTitle: {
         type: "boolean",
@@ -166,17 +248,26 @@ export function getConfigSchema(): PluginConfigSchema {
       pointsTitle: {
         type: "number",
         label: "Points — title",
-        showWhen: [{ field: "enabled", value: true }, { field: "matchTitle", value: true }],
+        showWhen: [
+          { field: "enabled", value: true },
+          { field: "matchTitle", value: true },
+        ],
       },
       pointsArtist: {
         type: "number",
         label: "Points — artist",
-        showWhen: [{ field: "enabled", value: true }, { field: "matchArtist", value: true }],
+        showWhen: [
+          { field: "enabled", value: true },
+          { field: "matchArtist", value: true },
+        ],
       },
       pointsAlbum: {
         type: "number",
         label: "Points — album",
-        showWhen: [{ field: "enabled", value: true }, { field: "matchAlbum", value: true }],
+        showWhen: [
+          { field: "enabled", value: true },
+          { field: "matchAlbum", value: true },
+        ],
       },
       speedMultiplier: {
         type: "number",
@@ -231,8 +322,7 @@ export function getConfigSchema(): PluginConfigSchema {
       messageTemplate: {
         type: "string",
         label: "System message template",
-        description:
-          "Variables: {{username}}, {{propertyLabel}}, {{points}}, {{multiplierSuffix}}",
+        description: "Variables: {{username}}, {{propertyLabel}}, {{points}}, {{multiplierSuffix}}",
         showWhen: { field: "enabled", value: true },
       },
     },

--- a/packages/plugin-guess-the-tune/types.ts
+++ b/packages/plugin-guess-the-tune/types.ts
@@ -1,7 +1,9 @@
 import { z } from "zod"
+import { participationModeSchema } from "@repo/game-logic"
 
 export const guessTheTuneConfigSchema = z.object({
   enabled: z.boolean().default(false),
+  mode: participationModeSchema,
   matchTitle: z.boolean().default(true),
   matchArtist: z.boolean().default(true),
   matchAlbum: z.boolean().default(true),
@@ -30,6 +32,7 @@ export type GuessTheTuneConfig = z.infer<typeof guessTheTuneConfigSchema>
 
 export const defaultGuessTheTuneConfig: GuessTheTuneConfig = {
   enabled: false,
+  mode: "inclusive",
   matchTitle: true,
   matchArtist: true,
   matchAlbum: true,

--- a/packages/plugin-loyalty-program/index.test.ts
+++ b/packages/plugin-loyalty-program/index.test.ts
@@ -53,6 +53,7 @@ function createMockContext(roomId: string = "room1"): PluginContext {
     getReactions: vi.fn().mockResolvedValue([]),
     getUsers: vi.fn().mockResolvedValue([]),
     getUsersByIds: vi.fn().mockResolvedValue([]),
+    isRoomAdmin: vi.fn().mockResolvedValue(true),
     skipTrack: vi.fn().mockResolvedValue(undefined),
     sendSystemMessage: vi.fn().mockResolvedValue(undefined),
     sendUserSystemMessage: vi.fn().mockResolvedValue(undefined),

--- a/packages/plugin-playlist-democracy/index.test.ts
+++ b/packages/plugin-playlist-democracy/index.test.ts
@@ -88,6 +88,7 @@ function createMockContext(roomId: string = "test-room"): PluginContext {
     getReactions: vi.fn().mockResolvedValue([]),
     getUsers: vi.fn().mockResolvedValue([]),
     getUsersByIds: vi.fn().mockResolvedValue([]),
+    isRoomAdmin: vi.fn().mockResolvedValue(true),
     getQueue: vi.fn().mockResolvedValue([]),
     skipTrack: vi.fn().mockResolvedValue(undefined),
     sendSystemMessage: vi.fn().mockResolvedValue(undefined),

--- a/packages/plugin-queue-hygiene/index.test.ts
+++ b/packages/plugin-queue-hygiene/index.test.ts
@@ -76,6 +76,7 @@ function createMockContext(roomId: string = "test-room"): PluginContext {
     getReactions: vi.fn().mockResolvedValue([]),
     getUsers: vi.fn().mockResolvedValue([]),
     getUsersByIds: vi.fn().mockResolvedValue([]),
+    isRoomAdmin: vi.fn().mockResolvedValue(true),
     getQueue: vi.fn().mockResolvedValue([]),
     skipTrack: vi.fn().mockResolvedValue(undefined),
     sendSystemMessage: vi.fn().mockResolvedValue(undefined),

--- a/packages/plugin-queue-pacer/index.test.ts
+++ b/packages/plugin-queue-pacer/index.test.ts
@@ -79,6 +79,7 @@ function createMockContext(roomId: string = "test-room"): PluginContext {
     getReactions: vi.fn().mockResolvedValue([]),
     getUsers: vi.fn().mockResolvedValue([]),
     getUsersByIds: vi.fn().mockResolvedValue([]),
+    isRoomAdmin: vi.fn().mockResolvedValue(true),
     getQueue: vi.fn().mockResolvedValue([]),
     skipTrack: vi.fn().mockResolvedValue(undefined),
     sendSystemMessage: vi.fn().mockResolvedValue(undefined),

--- a/packages/server/handlers/messageHandlersAdapter.test.ts
+++ b/packages/server/handlers/messageHandlersAdapter.test.ts
@@ -120,6 +120,25 @@ describe("MessageHandlers", () => {
       }, expect.any(Object))
     })
 
+    test("skips sendMessage when transformChatMessage returns drop", async () => {
+      mockSocket.context.pluginRegistry = {
+        transformChatMessage: vi.fn().mockResolvedValue({ drop: true, reason: "spoiler" }),
+      }
+
+      await messageHandlers.newMessage(
+        { socket: mockSocket as any, io: mockIo as any },
+        "Hello world",
+      )
+
+      expect(mockSocket.context.pluginRegistry.transformChatMessage).toHaveBeenCalled()
+      expect(sendMessage).not.toHaveBeenCalled()
+      expect(mockSocket.context.systemEvents.emit).toHaveBeenCalledWith(
+        "room1",
+        "TYPING_CHANGED",
+        { roomId: "room1", typing: mockTypingUsers },
+      )
+    })
+
     test("delays send when user has stacked chat_buffer modifiers", async () => {
       vi.useFakeTimers()
       const now = 1_700_000_000_000

--- a/packages/server/handlers/messageHandlersAdapter.ts
+++ b/packages/server/handlers/messageHandlersAdapter.ts
@@ -3,7 +3,7 @@ import { HandlerConnections } from "@repo/types/HandlerConnections"
 import { MessageService } from "../services/MessageService"
 import sendMessage from "../lib/sendMessage"
 import { expirableChatMessage } from "../lib/systemMessage"
-import { AppContext } from "@repo/types"
+import { AppContext, isChatMessageTransformDrop } from "@repo/types"
 import type { GameSessionService } from "../services/GameSessionService"
 
 /**
@@ -87,12 +87,16 @@ export class MessageHandlers {
     }
 
     const registry = socket.context.pluginRegistry
-    const messageToSend = registry
+    const transformResult = registry
       ? await registry.transformChatMessage(roomId, result.message)
       : result.message
 
+    if (isChatMessageTransformDrop(transformResult)) {
+      return
+    }
+
     // Send the message (broadcasts via SystemEvents)
-    await sendMessage(io, roomId, messageToSend, socket.context)
+    await sendMessage(io, roomId, transformResult, socket.context)
   }
 
   /**

--- a/packages/server/lib/plugins/PluginAPI.ts
+++ b/packages/server/lib/plugins/PluginAPI.ts
@@ -92,6 +92,18 @@ export class PluginAPIImpl implements PluginAPI {
     return getUsersByIds({ context: this.context, userIds })
   }
 
+  async isRoomAdmin(roomId: string, userId: string): Promise<boolean> {
+    const { findRoom, isRoomAdmin } = await import("../../operations/data")
+    const room = await findRoom({ context: this.context, roomId })
+    if (!room) return false
+    return isRoomAdmin({
+      context: this.context,
+      roomId,
+      userId,
+      roomCreator: room.creator,
+    })
+  }
+
   async skipTrack(roomId: string, trackId: string): Promise<void> {
     // Verify the track is still playing before skipping
     const nowPlaying = await this.getNowPlaying(roomId)

--- a/packages/server/lib/plugins/PluginRegistry.transformChatMessage.test.ts
+++ b/packages/server/lib/plugins/PluginRegistry.transformChatMessage.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from "vitest"
+import type { ChatMessage, Plugin } from "@repo/types"
+import { PluginLifecycleImpl } from "./PluginLifecycle"
+import { PluginRegistry } from "./PluginRegistry"
+
+function createMessage(content = "guess"): ChatMessage {
+  return {
+    content,
+    timestamp: "2026-01-01T00:00:00.000Z",
+    user: { userId: "u1", username: "Alice" },
+  }
+}
+
+function seedRoomPlugin(
+  registry: PluginRegistry,
+  roomId: string,
+  pluginName: string,
+  transform: NonNullable<Plugin["transformChatMessage"]>,
+): void {
+  const plugin = {
+    name: pluginName,
+    version: "1.0.0",
+    register: vi.fn(),
+    cleanup: vi.fn(),
+    transformChatMessage: transform,
+  } satisfies Plugin
+
+  const roomPlugins = (registry as unknown as { roomPlugins: Map<string, Map<string, unknown>> })
+    .roomPlugins
+  if (!roomPlugins.has(roomId)) {
+    roomPlugins.set(roomId, new Map())
+  }
+  roomPlugins.get(roomId)!.set(pluginName, {
+    plugin,
+    lifecycle: new PluginLifecycleImpl(),
+  })
+}
+
+describe("PluginRegistry.transformChatMessage", () => {
+  it("returns drop sentinel immediately without calling later plugins", async () => {
+    const registry = new PluginRegistry({} as never, {} as never)
+    const secondTransform = vi.fn(async () => null)
+
+    seedRoomPlugin(registry, "room1", "first", async () => ({ drop: true, reason: "spoiler" }))
+    seedRoomPlugin(registry, "room1", "second", secondTransform)
+
+    const result = await registry.transformChatMessage("room1", createMessage())
+
+    expect(result).toEqual({ drop: true, reason: "spoiler" })
+    expect(secondTransform).not.toHaveBeenCalled()
+  })
+
+  it("passes transformed message through sequential plugins", async () => {
+    const registry = new PluginRegistry({} as never, {} as never)
+
+    seedRoomPlugin(registry, "room1", "first", async (_roomId, message) => ({
+      ...message,
+      content: `${message.content}-a`,
+    }))
+    seedRoomPlugin(registry, "room1", "second", async (_roomId, message) => ({
+      ...message,
+      content: `${message.content}-b`,
+    }))
+
+    const result = await registry.transformChatMessage("room1", createMessage("x"))
+
+    expect(result).toEqual(expect.objectContaining({ content: "x-a-b" }))
+  })
+})

--- a/packages/server/lib/plugins/PluginRegistry.ts
+++ b/packages/server/lib/plugins/PluginRegistry.ts
@@ -1,6 +1,8 @@
 import {
   AppContext,
   ChatMessage,
+  ChatMessageTransformDrop,
+  ChatMessageTransformResult,
   DefenseTriggeredPayload,
   DefenseTriggeredResult,
   InventoryItem,
@@ -19,6 +21,7 @@ import {
   PluginMarkdownContext,
   QueueValidationParams,
   QueueValidationResult,
+  isChatMessageTransformDrop,
 } from "@repo/types"
 import { Server } from "socket.io"
 import { PluginAPIImpl } from "./PluginAPI"
@@ -308,8 +311,12 @@ export class PluginRegistry {
    * Run `transformChatMessage` on all plugins in the room that implement it.
    * Plugins are called in map iteration order; each receives the output of the
    * previous. Fail-open on errors and timeouts (same 500ms as queue validation).
+   * When any plugin returns `{ drop: true }`, remaining plugins are skipped.
    */
-  async transformChatMessage(roomId: string, message: ChatMessage): Promise<ChatMessage> {
+  async transformChatMessage(
+    roomId: string,
+    message: ChatMessage,
+  ): Promise<ChatMessage | ChatMessageTransformDrop> {
     const roomPluginMap = this.roomPlugins.get(roomId)
 
     if (!roomPluginMap || roomPluginMap.size === 0) {
@@ -330,13 +337,17 @@ export class PluginRegistry {
       try {
         const next = await Promise.race([
           plugin.transformChatMessage!(roomId, current),
-          new Promise<ChatMessage | null>((_, reject) =>
+          new Promise<ChatMessageTransformResult>((_, reject) =>
             setTimeout(
               () => reject(new Error("timeout")),
               PluginRegistry.VALIDATION_TIMEOUT_MS,
             ),
           ),
         ])
+
+        if (isChatMessageTransformDrop(next)) {
+          return next
+        }
 
         if (next != null) {
           current = next

--- a/packages/types/Plugin.ts
+++ b/packages/types/Plugin.ts
@@ -265,6 +265,11 @@ export interface PluginAPI {
   getUsers(roomId: string, params?: { status?: "listening" | "participating" }): Promise<User[]>
   /** Look up users by their IDs (includes users who have left the room) */
   getUsersByIds(userIds: string[]): Promise<User[]>
+  /**
+   * Whether the user is a room admin (creator or member of `room:{id}:admins`).
+   * Plugins should use this for defense-in-depth on admin-only `executeAction` handlers.
+   */
+  isRoomAdmin(roomId: string, userId: string): Promise<boolean>
   skipTrack(roomId: string, trackId: string): Promise<void>
   sendSystemMessage(
     roomId: string,
@@ -718,6 +723,15 @@ export interface PluginElementProps {
 }
 
 /**
+ * Per-user reveal overrides broadcast in {@link PluginAugmentationData.userReveals}.
+ * Clients consult only the current viewer's row (see ADR 0062).
+ */
+export type PluginUserReveals = Record<
+  string,
+  Partial<Record<PluginTextElementKey, NonNullable<PluginElementProps["revealedBy"]>>>
+>
+
+/**
  * Plugin data returned from augmentation methods.
  * Can include style hints and any plugin-specific metadata.
  */
@@ -729,6 +743,11 @@ export interface PluginAugmentationData {
    * Merged per-plugin under `QueueItem.pluginData[pluginName]`.
    */
   elementProps?: Partial<Record<PluginElementKey, PluginElementProps>>
+  /**
+   * Per-user reveal overrides for inclusive participation modes (ADR 0062).
+   * Broadcast to all clients; each viewer applies only their own row in the UI.
+   */
+  userReveals?: PluginUserReveals
   /** Any other plugin-specific data */
   [key: string]: any
 }
@@ -751,6 +770,31 @@ export interface QueueValidationParams {
  * Result of a queue validation check
  */
 export type QueueValidationResult = { allowed: true } | { allowed: false; reason: string }
+
+/**
+ * Sentinel returned from {@link Plugin.transformChatMessage} to skip persistence and broadcast.
+ * System messages may still be sent separately by the plugin.
+ *
+ * @see [ADR 0062](../docs/adrs/0062-participation-mode-pvp-vs-pvg.md)
+ */
+export interface ChatMessageTransformDrop {
+  drop: true
+  reason?: string
+}
+
+/** Return value from {@link Plugin.transformChatMessage}. */
+export type ChatMessageTransformResult = ChatMessage | null | ChatMessageTransformDrop
+
+export function isChatMessageTransformDrop(
+  result: ChatMessageTransformResult | undefined,
+): result is ChatMessageTransformDrop {
+  return (
+    result != null &&
+    typeof result === "object" &&
+    "drop" in result &&
+    (result as ChatMessageTransformDrop).drop === true
+  )
+}
 
 /**
  * Helper to create an "allowed" queue validation response.
@@ -885,12 +929,17 @@ export interface Plugin {
    * Transform a chat message before it is persisted and broadcast.
    * Called sequentially for each enabled plugin in the room; each sees the
    * previous plugin's result. Return `null` or `undefined` to leave the message
-   * unchanged. Fail-open on errors/timeouts (like `validateQueueRequest`).
+   * unchanged. Return `{ drop: true }` to skip persistence and broadcast
+   * (system messages may still be sent separately). Fail-open on errors/timeouts
+   * (like `validateQueueRequest`).
    *
    * @param roomId - Room id
    * @param message - The fully parsed message (after mentions / Mustache)
    */
-  transformChatMessage?(roomId: string, message: ChatMessage): Promise<ChatMessage | null>
+  transformChatMessage?(
+    roomId: string,
+    message: ChatMessage,
+  ): Promise<ChatMessageTransformResult>
 
   /**
    * Optional method to augment playlist items with plugin-specific metadata.

--- a/packages/types/PluginComponent.ts
+++ b/packages/types/PluginComponent.ts
@@ -121,6 +121,26 @@ export interface IconComponentProps {
 }
 
 /**
+ * Chakra `colorPalette` values for plugin buttons.
+ * Prefer theme palettes (`primary`, `secondary`, `action`) for branded UI;
+ * use semantic palettes (`red`, `green`, etc.) for status/destructive actions.
+ */
+export type PluginButtonColorPalette =
+  | "primary"
+  | "secondary"
+  | "action"
+  | "gray"
+  | "red"
+  | "orange"
+  | "yellow"
+  | "green"
+  | "teal"
+  | "blue"
+  | "cyan"
+  | "purple"
+  | "pink"
+
+/**
  * Props for the button template component.
  *
  * A button may either open a modal (`opensModal`) or invoke a plugin action
@@ -141,7 +161,9 @@ export interface ButtonComponentProps {
   /** Confirmation button label (defaults to "Confirm"). */
   confirmText?: string
   variant?: "solid" | "ghost" | "outline" | "link"
-  size?: "sm" | "md" | "lg"
+  size?: "xs" | "sm" | "md" | "lg"
+  /** Chakra color palette (see `PluginButtonColorPalette`). */
+  colorPalette?: PluginButtonColorPalette
   /** When true, the button is non-interactive. */
   disabled?: boolean
   /** When true, only room admins see this button (server must still enforce in executeAction). */


### PR DESCRIPTION
Supports an "inclusive" PvG mode in Guess The Tune: correct guesses are tracked on each user individually, not a race to the correct answer. Everyone can score. Also adds admin-only reveal buttons to the now playing section.