### PR TITLE
App-controlled queue: auto advance toggle and playback state buttons

### DIFF
--- a/apps/scheduler/src/components/segments/SegmentRoomSettingsEditor.tsx
+++ b/apps/scheduler/src/components/segments/SegmentRoomSettingsEditor.tsx
@@ -39,6 +39,12 @@ const ROWS: {
     helper: "Display the list of upcoming queued tracks in the playlist drawer.",
   },
   {
+    key: "queueAutoAdvance",
+    label: "Queue auto-advance",
+    helper:
+      "When enabled in app-controlled playback, the next queued track starts automatically at song end.",
+  },
+  {
     key: "fetchMeta",
     label: "Track detection",
     helper:

--- a/apps/scheduler/src/lib/segmentRoomSettingsTriState.ts
+++ b/apps/scheduler/src/lib/segmentRoomSettingsTriState.ts
@@ -10,6 +10,7 @@ const KEYS = [
   "deputizeOnJoin",
   "showQueueCount",
   "showQueueTracks",
+  "queueAutoAdvance",
   "fetchMeta",
   "announceNowPlaying",
 ] as const
@@ -31,6 +32,7 @@ export function overrideToAllTriStates(
     deputizeOnJoin: overrideToTriState(override, "deputizeOnJoin"),
     showQueueCount: overrideToTriState(override, "showQueueCount"),
     showQueueTracks: overrideToTriState(override, "showQueueTracks"),
+    queueAutoAdvance: overrideToTriState(override, "queueAutoAdvance"),
     fetchMeta: overrideToTriState(override, "fetchMeta"),
     announceNowPlaying: overrideToTriState(override, "announceNowPlaying"),
   }

--- a/apps/web/src/components/Modals/Admin/DjFeatures.tsx
+++ b/apps/web/src/components/Modals/Admin/DjFeatures.tsx
@@ -90,7 +90,7 @@ function DjFeatures() {
                   <Field.HelperText>
                     Spotify-controlled adds tracks to the Spotify queue (default). App-controlled
                     keeps order in the room queue only; the app starts the next track when the
-                    current one ends.
+                    current one ends unless auto-advance is turned off in the queue panel.
                   </Field.HelperText>
                 </Field.Root>
               ) : null}

--- a/apps/web/src/components/QueuedTracksSection.tsx
+++ b/apps/web/src/components/QueuedTracksSection.tsx
@@ -1,7 +1,6 @@
-import { useMemo, useRef, useCallback, memo } from "react"
+import { useMemo, useRef, useCallback, memo, useState, useEffect } from "react"
 import {
   Box,
-  Button,
   Heading,
   HStack,
   Badge,
@@ -9,6 +8,8 @@ import {
   Text,
   VStack,
   ScrollArea,
+  Checkbox,
+  IconButton,
 } from "@chakra-ui/react"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { DragDropProvider, DragOverlay } from "@dnd-kit/react"
@@ -17,6 +18,7 @@ import { isSortable } from "@dnd-kit/react/sortable"
 import { move } from "@dnd-kit/helpers"
 import { canonicalQueueTrackKey, type QueueItem as SharedQueueItem } from "@repo/types/Queue"
 import { GripVertical } from "lucide-react"
+import { LuPlay, LuPause } from "react-icons/lu"
 import { QueueItem } from "../types/Queue"
 import {
   useQueueList,
@@ -30,10 +32,13 @@ import socket from "../lib/socket"
 import { toast } from "../lib/toasts"
 import PlaylistItem from "./PlaylistItem"
 import ButtonAddToQueue from "./ButtonAddToQueue"
+import { Tooltip } from "./ui/tooltip"
 import type { Room } from "../types/Room"
 
 const ITEM_HEIGHT = 70
 const MAX_LIST_HEIGHT = 200
+
+type SpotifyPlaybackState = "playing" | "paused" | "stopped"
 
 export const ROOM_QUEUE_SORTABLE_GROUP = "room-queue"
 
@@ -132,6 +137,85 @@ function QueuedTracksSection() {
   const canResumeOrEmptyControls = isAppControlled && (isRoomCreator || isAdmin)
   const canReorder = useCanReorderQueue()
 
+  const [spotifyPlaybackState, setSpotifyPlaybackState] = useState<SpotifyPlaybackState | null>(
+    null,
+  )
+  const [playbackTogglePending, setPlaybackTogglePending] = useState(false)
+
+  useEffect(() => {
+    if (!canResumeOrEmptyControls) return
+
+    const onEvent = (payload: {
+      type?: string
+      data?: {
+        state?: SpotifyPlaybackState
+        message?: string
+        action?: string
+        trackTitle?: string
+      }
+    }) => {
+      if (payload.type === "PLAYBACK_STATE" && payload.data?.state) {
+        setSpotifyPlaybackState(payload.data.state)
+      }
+      if (payload.type === "PLAYBACK_STATE_CHANGED" && payload.data?.state) {
+        setSpotifyPlaybackState(payload.data.state)
+      }
+      if (payload.type === "GET_PLAYBACK_STATE_FAILURE") {
+        setSpotifyPlaybackState(null)
+      }
+      if (payload.type === "TOGGLE_PLAYBACK_SUCCESS") {
+        setPlaybackTogglePending(false)
+        if (payload.data?.state) {
+          setSpotifyPlaybackState(payload.data.state)
+        }
+        if (payload.data?.action === "advanced" && payload.data.trackTitle) {
+          toast({
+            title: "Now playing",
+            description: payload.data.trackTitle,
+            type: "success",
+            duration: 3000,
+          })
+        }
+      }
+      if (payload.type === "TOGGLE_PLAYBACK_FAILURE") {
+        setPlaybackTogglePending(false)
+        toast({
+          title: "Couldn't control playback",
+          description: payload.data?.message,
+          type: "error",
+          duration: 4000,
+        })
+      }
+    }
+
+    socket.on("event", onEvent)
+    emitToSocket("GET_PLAYBACK_STATE", {})
+
+    return () => {
+      socket.off("event", onEvent)
+    }
+  }, [canResumeOrEmptyControls])
+
+  const handleTogglePlayback = useCallback(() => {
+    setPlaybackTogglePending(true)
+    let timeoutId: number
+    const onEvent = (payload: { type?: string }) => {
+      if (
+        payload.type === "TOGGLE_PLAYBACK_SUCCESS" ||
+        payload.type === "TOGGLE_PLAYBACK_FAILURE"
+      ) {
+        socket.off("event", onEvent)
+        window.clearTimeout(timeoutId)
+      }
+    }
+    socket.on("event", onEvent)
+    timeoutId = window.setTimeout(() => {
+      socket.off("event", onEvent)
+      setPlaybackTogglePending(false)
+    }, 10000)
+    emitToSocket("TOGGLE_PLAYBACK", {})
+  }, [])
+
   const showQueueTracks = isAdmin || room?.showQueueTracks !== false
   const queueTracksHiddenFromListeners = isAdmin && room?.showQueueTracks === false
 
@@ -172,32 +256,10 @@ function QueuedTracksSection() {
     [orderedKeys],
   )
 
-  const handleResumePlayback = useCallback(() => {
-    let timeoutId: number
-    const onEvent = (payload: { type?: string; data?: { message?: string } }) => {
-      if (payload.type === "RESUME_PLAYBACK_SUCCESS") {
-        socket.off("event", onEvent)
-        window.clearTimeout(timeoutId)
-        toast({
-          title: "Playback resumed",
-          type: "success",
-          duration: 3000,
-        })
-      }
-      if (payload.type === "RESUME_PLAYBACK_FAILURE") {
-        socket.off("event", onEvent)
-        window.clearTimeout(timeoutId)
-        toast({
-          title: "Couldn't resume playback",
-          description: payload.data?.message,
-          type: "error",
-          duration: 4000,
-        })
-      }
-    }
-    socket.on("event", onEvent)
-    timeoutId = window.setTimeout(() => socket.off("event", onEvent), 10000)
-    emitToSocket("RESUME_PLAYBACK", {})
+  const queueAutoAdvance = room?.queueAutoAdvance !== false
+
+  const handleQueueAutoAdvanceChange = useCallback((checked: boolean) => {
+    emitToSocket("SET_ROOM_SETTINGS", { queueAutoAdvance: checked })
   }, [])
 
   const virtualRowCount = queue.length
@@ -334,17 +396,51 @@ function QueuedTracksSection() {
               {badgeCount}
             </Badge>
           </HStack>
-          {canResumeOrEmptyControls && (
-            <Button
-              variant="outline"
-              colorPalette="primary"
-              size="xs"
-              onClick={handleResumePlayback}
-            >
-              Resume
-            </Button>
-          )}
-          <ButtonAddToQueue variant="solid" colorPalette="primary" size="xs" showCount={false} />
+          <HStack gap={2} justify="end">
+            {canResumeOrEmptyControls && (
+              <Checkbox.Root
+                checked={queueAutoAdvance}
+                onCheckedChange={(details) => {
+                  handleQueueAutoAdvanceChange(details.checked === true)
+                }}
+                size="sm"
+                title="When off, the next queued track won't start automatically at song end"
+              >
+                <Checkbox.HiddenInput />
+                <Checkbox.Control>
+                  <Checkbox.Indicator />
+                </Checkbox.Control>
+                <Checkbox.Label fontSize="xs">Auto-advance</Checkbox.Label>
+              </Checkbox.Root>
+            )}
+            {canResumeOrEmptyControls && (
+              <Tooltip
+                content={
+                  spotifyPlaybackState === "playing"
+                    ? "Pause show music playback on Spotify"
+                    : "Resume show music or start the next queued track"
+                }
+                positioning={{ placement: "top" }}
+              >
+                <IconButton
+                  aria-label={
+                    spotifyPlaybackState === "playing"
+                      ? "Pause show music playback"
+                      : "Play show music"
+                  }
+                  variant="outline"
+                  colorPalette="primary"
+                  size="xs"
+                  onClick={handleTogglePlayback}
+                  loading={playbackTogglePending}
+                  disabled={playbackTogglePending}
+                >
+                  {spotifyPlaybackState === "playing" ? <LuPause /> : <LuPlay />}
+                </IconButton>
+              </Tooltip>
+            )}
+            <ButtonAddToQueue variant="solid" colorPalette="primary" size="xs" showCount={false} />
+          </HStack>
         </HStack>
         {virtualRowCount > 0 ? (
           <Box w="100%">

--- a/apps/web/src/components/QueuedTracksSection.tsx
+++ b/apps/web/src/components/QueuedTracksSection.tsx
@@ -367,6 +367,17 @@ function QueuedTracksSection() {
 
   const badgeCount = virtualRowCount
 
+  const showMusicPlayDisabled =
+    playbackTogglePending ||
+    (spotifyPlaybackState !== "playing" && queue.length === 0)
+
+  const showMusicPlaybackTooltip =
+    spotifyPlaybackState === "playing"
+      ? "Pause show music playback on Spotify"
+      : queue.length === 0
+        ? "Nothing in the queue to play"
+        : "Resume show music or start the next queued track"
+
   return (
     <Box
       background="primary.subtle/20"
@@ -414,29 +425,24 @@ function QueuedTracksSection() {
               </Checkbox.Root>
             )}
             {canResumeOrEmptyControls && (
-              <Tooltip
-                content={
-                  spotifyPlaybackState === "playing"
-                    ? "Pause show music playback on Spotify"
-                    : "Resume show music or start the next queued track"
-                }
-                positioning={{ placement: "top" }}
-              >
-                <IconButton
-                  aria-label={
-                    spotifyPlaybackState === "playing"
-                      ? "Pause show music playback"
-                      : "Play show music"
-                  }
-                  variant="outline"
-                  colorPalette="primary"
-                  size="xs"
-                  onClick={handleTogglePlayback}
-                  loading={playbackTogglePending}
-                  disabled={playbackTogglePending}
-                >
-                  {spotifyPlaybackState === "playing" ? <LuPause /> : <LuPlay />}
-                </IconButton>
+              <Tooltip content={showMusicPlaybackTooltip} positioning={{ placement: "top" }}>
+                <Box as="span" display="inline-flex">
+                  <IconButton
+                    aria-label={
+                      spotifyPlaybackState === "playing"
+                        ? "Pause show music playback"
+                        : "Play show music"
+                    }
+                    variant="outline"
+                    colorPalette="primary"
+                    size="xs"
+                    onClick={handleTogglePlayback}
+                    loading={playbackTogglePending}
+                    disabled={showMusicPlayDisabled}
+                  >
+                    {spotifyPlaybackState === "playing" ? <LuPause /> : <LuPlay />}
+                  </IconButton>
+                </Box>
               </Tooltip>
             )}
             <ButtonAddToQueue variant="solid" colorPalette="primary" size="xs" showCount={false} />

--- a/apps/web/src/types/Room.ts
+++ b/apps/web/src/types/Room.ts
@@ -44,6 +44,8 @@ export type Room = {
   // Queue display settings (default true)
   showQueueCount?: boolean
   showQueueTracks?: boolean
+  /** App-controlled only. When false, admins advance manually; default true. */
+  queueAutoAdvance?: boolean
   // Chat settings
   /** When true, non-admin listeners may upload images in chat; room admins may always upload. */
   allowChatImages?: boolean

--- a/docs/adrs/0040-app-controlled-playback-and-ordered-queue.md
+++ b/docs/adrs/0040-app-controlled-playback-and-ordered-queue.md
@@ -23,6 +23,8 @@ The legacy app queue used a Redis **SET** plus JSON blobs; member order was unde
 
 5. **Queue payloads over the wire**: After dispatch (advance job or explicit Play), the popped item still appears in **`QUEUE_CHANGED`** as the first queue row with **`locked: true`** until Shoutcast matches now-playing and dispatched Redis state is cleared — clients do not need a separate dispatched concept or extra event.
 
+6. **`Room.queueAutoAdvance`** (default **true** when unset): Gates the track advance job in app-controlled mode. When **false**, the job does not pop or start the next track at song end; room admins advance manually via **`PLAY_QUEUED_TRACK`** (per-row Play control) or **`TOGGLE_PLAYBACK`** (queue-header play/pause, which resumes mid-track or starts the next queued item when the previous song has finished). Segment **`roomSettingsOverride`** may set this on activation. Plugin-driven **`skipTrack`** is unaffected.
+
 ## Consequences
 
 - **Game-ready ordering**: Reordering is future `ZADD` score updates without storage migration.

--- a/packages/adapter-spotify/lib/playbackControllerApi.ts
+++ b/packages/adapter-spotify/lib/playbackControllerApi.ts
@@ -170,14 +170,22 @@ export async function makeApi({
         return {
           state: "paused" as const,
           track: null,
+          progressMs: null,
+          durationMs: null,
         }
       }
 
-      const { is_playing, item } = playback
+      const { is_playing, item, progress_ms } = playback
+      const durationMs =
+        item && typeof item === "object" && "duration_ms" in item
+          ? (item as { duration_ms?: number }).duration_ms ?? null
+          : null
 
       return {
         state: is_playing ? "playing" : "paused",
         track: item ? trackItemSchema.parse(item) : null,
+        progressMs: progress_ms ?? null,
+        durationMs,
       }
     },
   }

--- a/packages/adapter-spotify/lib/trackAdvanceJob.test.ts
+++ b/packages/adapter-spotify/lib/trackAdvanceJob.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { roomFactory } from "@repo/factories/room"
+import { createTrackAdvanceJob } from "./trackAdvanceJob"
+
+const popNextFromQueue = vi.fn()
+const findRoom = vi.fn()
+const handlePlaybackStateChange = vi.fn()
+
+vi.mock("@repo/server/operations/data", () => ({
+  findRoom: (...args: unknown[]) => findRoom(...args),
+  addToQueue: vi.fn(),
+  clearDispatchedTrack: vi.fn(),
+  popNextFromQueue: (...args: unknown[]) => popNextFromQueue(...args),
+  getDispatchedTrack: vi.fn().mockResolvedValue(null),
+  setDispatchedTrack: vi.fn(),
+  getQueueWithDispatched: vi.fn(),
+}))
+
+vi.mock("@repo/server/operations/playback/handlePlaybackStateChange", () => ({
+  handlePlaybackStateChange: (...args: unknown[]) => handlePlaybackStateChange(...args),
+  playbackStateFromIsPlaying: (isPlaying: boolean) => (isPlaying ? "playing" : "paused"),
+}))
+
+const getPlaybackState = vi.fn()
+
+vi.mock("@spotify/web-api-ts-sdk", () => ({
+  SpotifyApi: {
+    withAccessToken: () => ({
+      player: {
+        getPlaybackState,
+      },
+    }),
+  },
+}))
+
+describe("createTrackAdvanceJob", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.SPOTIFY_CLIENT_ID = "test-client-id"
+    findRoom.mockResolvedValue(
+      roomFactory.build({
+        id: "room1",
+        playbackMode: "app-controlled",
+        queueAutoAdvance: false,
+      }),
+    )
+    getPlaybackState.mockResolvedValue({
+      is_playing: true,
+      progress_ms: 179_000,
+      item: { id: "track1", duration_ms: 180_000 },
+    })
+  })
+
+  it("does not pop the queue when queueAutoAdvance is disabled", async () => {
+    const job = createTrackAdvanceJob({
+      context: {
+        data: {
+          getUserServiceAuth: vi.fn().mockResolvedValue({
+            accessToken: "token",
+            refreshToken: "refresh",
+          }),
+        },
+      } as never,
+      roomId: "room1",
+      userId: "user1",
+      playTrack: vi.fn(),
+    })
+
+    await job.handler({ api: {} as never, context: {} as never })
+
+    expect(handlePlaybackStateChange).toHaveBeenCalled()
+    expect(popNextFromQueue).not.toHaveBeenCalled()
+  })
+})

--- a/packages/adapter-spotify/lib/trackAdvanceJob.ts
+++ b/packages/adapter-spotify/lib/trackAdvanceJob.ts
@@ -62,7 +62,7 @@ export function createTrackAdvanceJob(params: {
           setDispatchedTrack,
           getQueueWithDispatched,
         } = await import("@repo/server/operations/data")
-        const { isAppControlledPlayback } = await import("@repo/server/lib/roomTypeHelpers")
+        const { isAppControlledPlayback, isQueueAutoAdvanceEnabled } = await import("@repo/server/lib/roomTypeHelpers")
         const {
           handlePlaybackStateChange,
           playbackStateFromIsPlaying,
@@ -121,6 +121,10 @@ export function createTrackAdvanceJob(params: {
         // Track advance: only for app-controlled playback rooms
         // =====================================================================
         if (!isAppControlledPlayback(room)) {
+          return
+        }
+
+        if (!isQueueAutoAdvanceEnabled(room)) {
           return
         }
 

--- a/packages/server/controllers/djController.test.ts
+++ b/packages/server/controllers/djController.test.ts
@@ -56,13 +56,14 @@ describe("DJController", () => {
       expect(mockSocket.on).toHaveBeenCalledWith("REMOVE_FROM_QUEUE", expect.any(Function))
       expect(mockSocket.on).toHaveBeenCalledWith("PLAY_QUEUED_TRACK", expect.any(Function))
       expect(mockSocket.on).toHaveBeenCalledWith("REORDER_QUEUE", expect.any(Function))
-      expect(mockSocket.on).toHaveBeenCalledWith("RESUME_PLAYBACK", expect.any(Function))
+      expect(mockSocket.on).toHaveBeenCalledWith("TOGGLE_PLAYBACK", expect.any(Function))
+      expect(mockSocket.on).toHaveBeenCalledWith("GET_PLAYBACK_STATE", expect.any(Function))
     })
 
-    test("should register exactly 14 socket events", () => {
+    test("should register exactly 15 socket events", () => {
       createDJController(mockSocket, mockIo)
 
-      expect(mockSocket.on).toHaveBeenCalledTimes(14)
+      expect(mockSocket.on).toHaveBeenCalledTimes(15)
     })
   })
 
@@ -119,7 +120,7 @@ describe("DJController", () => {
       createDJController(mockSocket, mockIo)
 
       // Verify that handlers were registered - if they were, the closure is working
-      expect(socketEventHandlers.size).toBe(14)
+      expect(socketEventHandlers.size).toBe(15)
     })
   })
 
@@ -131,7 +132,7 @@ describe("DJController", () => {
 
       createDJController(mockSocket, mockIo)
 
-      expect(mockSocket.on).toHaveBeenCalledTimes(14)
+      expect(mockSocket.on).toHaveBeenCalledTimes(15)
     })
 
     test("shows handler reuse through closure", () => {
@@ -141,7 +142,7 @@ describe("DJController", () => {
       createDJController(mockSocket, mockIo)
 
       // All events are registered using the same handler instance
-      expect(socketEventHandlers.size).toBe(14)
+      expect(socketEventHandlers.size).toBe(15)
     })
   })
 })

--- a/packages/server/controllers/djController.ts
+++ b/packages/server/controllers/djController.ts
@@ -134,8 +134,12 @@ export function createDJController(socket: SocketWithContext, io: Server): void 
     await handlers.reorderQueue(connections, payload)
   })
 
-  socket.on("RESUME_PLAYBACK", async () => {
-    await handlers.resumePlayback(connections)
+  socket.on("TOGGLE_PLAYBACK", async () => {
+    await handlers.togglePlayback(connections)
+  })
+
+  socket.on("GET_PLAYBACK_STATE", async () => {
+    await handlers.getPlaybackState(connections)
   })
 }
 

--- a/packages/server/handlers/djHandlersAdapter.ts
+++ b/packages/server/handlers/djHandlersAdapter.ts
@@ -602,25 +602,61 @@ export class DJHandlers {
     }
   }
 
-  resumePlayback = async ({ socket }: HandlerConnections) => {
+  togglePlayback = async ({ socket }: HandlerConnections) => {
     try {
       const { roomId, userId } = socket.data
-      const result = await this.djService.resumePlayback(roomId, userId)
+      const result = await this.djService.togglePlayback(roomId, userId)
 
       if (!result.success) {
         socket.emit("event", {
-          type: "RESUME_PLAYBACK_FAILURE",
+          type: "TOGGLE_PLAYBACK_FAILURE",
           data: { message: result.message },
         })
         return
       }
 
-      socket.emit("event", { type: "RESUME_PLAYBACK_SUCCESS" })
-    } catch (error: any) {
-      console.error("Error resuming playback:", error)
       socket.emit("event", {
-        type: "RESUME_PLAYBACK_FAILURE",
-        data: { message: error?.message || "Failed to resume playback" },
+        type: "TOGGLE_PLAYBACK_SUCCESS",
+        data: {
+          state: result.state,
+          action: result.action,
+          trackTitle: "trackTitle" in result ? result.trackTitle : undefined,
+        },
+      })
+    } catch (error: any) {
+      console.error("Error toggling playback:", error)
+      socket.emit("event", {
+        type: "TOGGLE_PLAYBACK_FAILURE",
+        data: { message: error?.message || "Failed to control playback" },
+      })
+    }
+  }
+
+  getPlaybackState = async ({ socket }: HandlerConnections) => {
+    try {
+      const { roomId, userId } = socket.data
+      const result = await this.djService.getPlaybackState(roomId, userId)
+
+      if (!result.success) {
+        socket.emit("event", {
+          type: "GET_PLAYBACK_STATE_FAILURE",
+          data: { message: result.message },
+        })
+        return
+      }
+
+      socket.emit("event", {
+        type: "PLAYBACK_STATE",
+        data: {
+          state: result.state,
+          trackId: result.trackId,
+        },
+      })
+    } catch (error: any) {
+      console.error("Error reading playback state:", error)
+      socket.emit("event", {
+        type: "GET_PLAYBACK_STATE_FAILURE",
+        data: { message: error?.message || "Failed to read playback state" },
       })
     }
   }

--- a/packages/server/lib/playbackHelpers.test.ts
+++ b/packages/server/lib/playbackHelpers.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest"
+import {
+  shouldAdvanceToNextQueueItem,
+  PLAYBACK_END_THRESHOLD_MS,
+  MID_TRACK_RESUME_MIN_MS,
+} from "./playbackHelpers"
+
+describe("shouldAdvanceToNextQueueItem", () => {
+  const queue = [{ locked: false }]
+
+  it("returns false when playing", () => {
+    expect(
+      shouldAdvanceToNextQueueItem(
+        { state: "playing", track: { id: "t1" }, progressMs: 1000, durationMs: 180_000 },
+        queue,
+      ),
+    ).toBe(false)
+  })
+
+  it("returns false when queue is empty", () => {
+    expect(
+      shouldAdvanceToNextQueueItem({ state: "paused", track: null, progressMs: null }, []),
+    ).toBe(false)
+  })
+
+  it("returns true when paused with no track context and queue has items", () => {
+    expect(
+      shouldAdvanceToNextQueueItem({ state: "paused", track: null, progressMs: null }, queue),
+    ).toBe(true)
+  })
+
+  it("returns true when paused near end of track", () => {
+    expect(
+      shouldAdvanceToNextQueueItem(
+        {
+          state: "paused",
+          track: { id: "t1" },
+          progressMs: 180_000 - PLAYBACK_END_THRESHOLD_MS,
+          durationMs: 180_000,
+        },
+        queue,
+      ),
+    ).toBe(true)
+  })
+
+  it("returns false when paused mid-track", () => {
+    expect(
+      shouldAdvanceToNextQueueItem(
+        { state: "paused", track: { id: "t1" }, progressMs: 60_000, durationMs: 180_000 },
+        queue,
+      ),
+    ).toBe(false)
+  })
+
+  it("returns true when auto-advance is off and progress reset to 0 after natural end", () => {
+    expect(
+      shouldAdvanceToNextQueueItem(
+        { state: "paused", track: { id: "t1" }, progressMs: 0, durationMs: 180_000 },
+        queue,
+        { queueAutoAdvance: false },
+      ),
+    ).toBe(true)
+  })
+
+  it("returns false when auto-advance is off but paused mid-track", () => {
+    expect(
+      shouldAdvanceToNextQueueItem(
+        {
+          state: "paused",
+          track: { id: "t1" },
+          progressMs: MID_TRACK_RESUME_MIN_MS + 5000,
+          durationMs: 180_000,
+        },
+        queue,
+        { queueAutoAdvance: false },
+      ),
+    ).toBe(false)
+  })
+
+  it("returns false when auto-advance is on and progress reset to 0 (resume finished track)", () => {
+    expect(
+      shouldAdvanceToNextQueueItem(
+        { state: "paused", track: { id: "t1" }, progressMs: 0, durationMs: 180_000 },
+        queue,
+        { queueAutoAdvance: true },
+      ),
+    ).toBe(false)
+  })
+})

--- a/packages/server/lib/playbackHelpers.ts
+++ b/packages/server/lib/playbackHelpers.ts
@@ -1,0 +1,76 @@
+/** Match trackAdvanceJob end window — treat playback as finished at or past this point. */
+export const PLAYBACK_END_THRESHOLD_MS = 1000
+
+/** Pauses at or above this position are treated as mid-track resume, not queue advance. */
+export const MID_TRACK_RESUME_MIN_MS = 1000
+
+export type PlaybackSnapshot = {
+  state: "playing" | "paused" | "stopped"
+  track: unknown | null
+  progressMs?: number | null
+  durationMs?: number | null
+}
+
+export type ShouldAdvanceOptions = {
+  /** When false, Play prefers the next queue item unless clearly mid-track paused. */
+  queueAutoAdvance?: boolean
+}
+
+function isMidTrackPause(progressMs: number, durationMs: number | null | undefined): boolean {
+  if (durationMs == null || durationMs <= 0) {
+    return false
+  }
+  return (
+    progressMs >= MID_TRACK_RESUME_MIN_MS &&
+    progressMs < durationMs - PLAYBACK_END_THRESHOLD_MS
+  )
+}
+
+function isNearTrackEnd(progressMs: number, durationMs: number | null | undefined): boolean {
+  if (durationMs == null || durationMs <= 0) {
+    return false
+  }
+  return progressMs >= durationMs - PLAYBACK_END_THRESHOLD_MS
+}
+
+/**
+ * When Spotify is not playing, decide whether Play should start the next queue item
+ * instead of resuming the current (finished) track.
+ *
+ * After a natural track end Spotify often resets `progress_ms` to 0 while keeping the
+ * same item — so end detection cannot rely on progress alone near the start.
+ */
+export function shouldAdvanceToNextQueueItem(
+  playback: PlaybackSnapshot,
+  queue: { locked?: boolean }[],
+  options: ShouldAdvanceOptions = {},
+): boolean {
+  const queueAutoAdvance = options.queueAutoAdvance !== false
+
+  if (playback.state === "playing" || queue.length === 0) {
+    return false
+  }
+
+  if (!playback.track) {
+    return true
+  }
+
+  const duration = playback.durationMs
+  const progress = playback.progressMs ?? 0
+
+  if (isMidTrackPause(progress, duration)) {
+    return false
+  }
+
+  if (isNearTrackEnd(progress, duration)) {
+    return true
+  }
+
+  // Manual-advance mode: idle Spotify with queue items should start the next track,
+  // including when the previous song ended and progress was reset to 0.
+  if (!queueAutoAdvance) {
+    return true
+  }
+
+  return false
+}

--- a/packages/server/lib/roomTypeHelpers.test.ts
+++ b/packages/server/lib/roomTypeHelpers.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest"
-import { hasListenableStream, isHybridRadioRoom } from "./roomTypeHelpers"
+import {
+  hasListenableStream,
+  isHybridRadioRoom,
+  isQueueAutoAdvanceEnabled,
+} from "./roomTypeHelpers"
 
 describe("hasListenableStream", () => {
   it("returns true for radio rooms", () => {
@@ -29,5 +33,18 @@ describe("isHybridRadioRoom", () => {
     expect(isHybridRadioRoom({ type: "radio", liveIngestEnabled: false })).toBe(false)
     expect(isHybridRadioRoom({ type: "live", liveIngestEnabled: true })).toBe(false)
     expect(isHybridRadioRoom(null)).toBe(false)
+  })
+})
+
+describe("isQueueAutoAdvanceEnabled", () => {
+  it("defaults to true when unset", () => {
+    expect(isQueueAutoAdvanceEnabled({})).toBe(true)
+    expect(isQueueAutoAdvanceEnabled(null)).toBe(true)
+    expect(isQueueAutoAdvanceEnabled(undefined)).toBe(true)
+  })
+
+  it("returns false only when explicitly disabled", () => {
+    expect(isQueueAutoAdvanceEnabled({ queueAutoAdvance: false })).toBe(false)
+    expect(isQueueAutoAdvanceEnabled({ queueAutoAdvance: true })).toBe(true)
   })
 })

--- a/packages/server/lib/roomTypeHelpers.ts
+++ b/packages/server/lib/roomTypeHelpers.ts
@@ -25,3 +25,10 @@ export function isAppControlledPlayback(
 ): boolean {
   return room?.playbackMode === "app-controlled"
 }
+
+/** App-controlled rooms only. Default true when unset. */
+export function isQueueAutoAdvanceEnabled(
+  room: Pick<Room, "queueAutoAdvance"> | null | undefined,
+): boolean {
+  return room?.queueAutoAdvance !== false
+}

--- a/packages/server/operations/activateRoomSegment.test.ts
+++ b/packages/server/operations/activateRoomSegment.test.ts
@@ -243,6 +243,59 @@ describe("activateRoomSegment", () => {
     })
   })
 
+  it("merges queueAutoAdvance from roomSettingsOverride into saveRoom", async () => {
+    m.findShowById.mockResolvedValueOnce({
+      id: "show-1",
+      segments: [
+        {
+          segmentId: "seg-1",
+          segment: {
+            id: "seg-1",
+            title: "Talk break",
+            pluginPreset: null,
+            roomSettingsOverride: { queueAutoAdvance: false },
+            duration: 5,
+            status: "ready",
+            description: null,
+            isRecurring: false,
+            createdBy: "u1",
+            assignedTo: null,
+            assignee: null,
+            createdAt: "",
+            updatedAt: "",
+          },
+        },
+      ],
+    })
+    m.findRoom
+      .mockReset()
+      .mockResolvedValueOnce(baseRoom({ activeSegmentId: null, queueAutoAdvance: true }))
+      .mockResolvedValueOnce(
+        baseRoom({
+          activeSegmentId: "seg-1",
+          queueAutoAdvance: false,
+        }),
+      )
+
+    await activateRoomSegment({
+      context,
+      roomId: "r1",
+      userId: "u1",
+      segmentId: "seg-1",
+      presetMode: "skip",
+    })
+
+    expect(m.saveRoom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context,
+        room: expect.objectContaining({
+          activeSegmentId: "seg-1",
+          queueAutoAdvance: false,
+        }),
+      }),
+    )
+  })
+
   it("passes deputyBulkAction to applySegmentDeputyBulkAction", async () => {
     m.findShowById.mockResolvedValueOnce({
       id: "show-1",

--- a/packages/server/operations/activateRoomSegment.ts
+++ b/packages/server/operations/activateRoomSegment.ts
@@ -28,6 +28,7 @@ function patchRoomFromSegmentOverride(override: SegmentRoomSettingsOverride | nu
   if (override.deputizeOnJoin !== undefined) p.deputizeOnJoin = override.deputizeOnJoin
   if (override.showQueueCount !== undefined) p.showQueueCount = override.showQueueCount
   if (override.showQueueTracks !== undefined) p.showQueueTracks = override.showQueueTracks
+  if (override.queueAutoAdvance !== undefined) p.queueAutoAdvance = override.queueAutoAdvance
   if (override.fetchMeta !== undefined) p.fetchMeta = override.fetchMeta
   if (override.announceNowPlaying !== undefined) p.announceNowPlaying = override.announceNowPlaying
   if (override.playbackMode !== undefined) p.playbackMode = override.playbackMode

--- a/packages/server/operations/data/rooms.ts
+++ b/packages/server/operations/data/rooms.ts
@@ -409,6 +409,7 @@ export function parseRoom(room: StoredRoom): Room {
     // Queue display settings default to true when undefined
     showQueueCount: room.showQueueCount !== "false",
     showQueueTracks: room.showQueueTracks !== "false",
+    queueAutoAdvance: room.queueAutoAdvance !== "false",
     // Chat settings default to false when undefined
     allowChatImages: room.allowChatImages === "true",
     showSchedulePublic: room.showSchedulePublic === "true",

--- a/packages/server/services/DJService.test.ts
+++ b/packages/server/services/DJService.test.ts
@@ -371,41 +371,135 @@ describe("DJService", () => {
     })
   })
 
-  describe("resumePlayback", () => {
+  describe("togglePlayback", () => {
+    const room = roomFactory.build({
+      creator: "user123",
+      playbackMode: "app-controlled",
+      playbackControllerId: "spotify",
+    })
+
     test("rejects when user is not creator or admin", async () => {
-      vi.mocked(findRoom).mockResolvedValue(
-        roomFactory.build({
-          creator: "someone-else",
-          playbackMode: "app-controlled",
-          playbackControllerId: "spotify",
-        }),
-      )
+      vi.mocked(findRoom).mockResolvedValue(room)
       vi.mocked(isRoomAdmin).mockResolvedValue(false)
 
-      const result = await djService.resumePlayback("room123", "user123")
+      const result = await djService.togglePlayback("room123", "user123")
 
       expect(result.success).toBe(false)
     })
 
-    test("calls Spotify play when user is room creator", async () => {
-      vi.mocked(findRoom).mockResolvedValue(
-        roomFactory.build({
-          creator: "user123",
-          playbackMode: "app-controlled",
-          playbackControllerId: "spotify",
-        }),
-      )
+    test("pauses when Spotify is playing", async () => {
+      vi.mocked(findRoom).mockResolvedValue(room)
       vi.mocked(isRoomAdmin).mockResolvedValue(true)
-      const play = vi.fn().mockResolvedValue(undefined)
+      const pause = vi.fn().mockResolvedValue(undefined)
+      const getPlayback = vi.fn().mockResolvedValue({
+        state: "playing" as const,
+        track: { id: "t1" },
+        progressMs: 30_000,
+        durationMs: 180_000,
+      })
       // @ts-ignore
       djService["adapterService"].getRoomPlaybackController = vi.fn().mockResolvedValue({
-        api: { play },
+        api: { getPlayback, pause, play: vi.fn() },
       })
 
-      const result = await djService.resumePlayback("room123", "user123")
+      const result = await djService.togglePlayback("room123", "user123")
+
+      expect(result).toEqual({ success: true, state: "paused", action: "paused" })
+      expect(pause).toHaveBeenCalled()
+    })
+
+    test("resumes when paused mid-track", async () => {
+      vi.mocked(findRoom).mockResolvedValue(room)
+      vi.mocked(isRoomAdmin).mockResolvedValue(true)
+      const play = vi.fn().mockResolvedValue(undefined)
+      const getPlayback = vi.fn().mockResolvedValue({
+        state: "paused" as const,
+        track: { id: "t1" },
+        progressMs: 30_000,
+        durationMs: 180_000,
+      })
+      vi.mocked(getQueue).mockResolvedValue([])
+      // @ts-ignore
+      djService["adapterService"].getRoomPlaybackController = vi.fn().mockResolvedValue({
+        api: { getPlayback, pause: vi.fn(), play },
+      })
+
+      const result = await djService.togglePlayback("room123", "user123")
+
+      expect(result).toEqual({ success: true, state: "playing", action: "resumed" })
+      expect(play).toHaveBeenCalled()
+    })
+
+    test("starts next queue item when previous track finished at progress 0", async () => {
+      const item = queueItemFactory.build({
+        track: {
+          ...queueItemFactory.build().track,
+          urls: [{ type: "resource" as const, url: "spotify:track:abc" }],
+        },
+        addedBy: { userId: "user123", username: "Host" },
+      })
+      vi.mocked(findRoom).mockResolvedValue({
+        ...room,
+        queueAutoAdvance: false,
+      })
+      vi.mocked(isRoomAdmin).mockResolvedValue(true)
+      vi.mocked(getQueue).mockResolvedValue([item])
+      const getPlayback = vi.fn().mockResolvedValue({
+        state: "paused" as const,
+        track: { id: "t1" },
+        progressMs: 0,
+        durationMs: 180_000,
+      })
+      const play = vi.fn().mockResolvedValue(undefined)
+      const playTrack = vi.fn().mockResolvedValue(undefined)
+      // @ts-ignore
+      djService["adapterService"].getRoomPlaybackController = vi.fn().mockResolvedValue({
+        api: { getPlayback, pause: vi.fn(), play, playTrack },
+      })
+
+      const result = await djService.togglePlayback("room123", "user123")
 
       expect(result.success).toBe(true)
-      expect(play).toHaveBeenCalled()
+      if (result.success) {
+        expect(result.action).toBe("advanced")
+      }
+      expect(playTrack).toHaveBeenCalled()
+      expect(play).not.toHaveBeenCalled()
+    })
+
+    test("starts next queue item when previous track finished near end", async () => {
+      const item = queueItemFactory.build({
+        track: {
+          ...queueItemFactory.build().track,
+          urls: [{ type: "resource" as const, url: "spotify:track:abc" }],
+        },
+        addedBy: { userId: "user123", username: "Host" },
+      })
+      vi.mocked(findRoom).mockResolvedValue({
+        ...room,
+        queueAutoAdvance: false,
+      })
+      vi.mocked(isRoomAdmin).mockResolvedValue(true)
+      vi.mocked(getQueue).mockResolvedValue([item])
+      const getPlayback = vi.fn().mockResolvedValue({
+        state: "paused" as const,
+        track: { id: "t1" },
+        progressMs: 179_500,
+        durationMs: 180_000,
+      })
+      const playTrack = vi.fn().mockResolvedValue(undefined)
+      // @ts-ignore
+      djService["adapterService"].getRoomPlaybackController = vi.fn().mockResolvedValue({
+        api: { getPlayback, pause: vi.fn(), play: vi.fn(), playTrack },
+      })
+
+      const result = await djService.togglePlayback("room123", "user123")
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.action).toBe("advanced")
+      }
+      expect(playTrack).toHaveBeenCalled()
     })
   })
 

--- a/packages/server/services/DJService.ts
+++ b/packages/server/services/DJService.ts
@@ -25,6 +25,7 @@ import { queueItemFactory } from "@repo/factories"
 import { AdapterService } from "./AdapterService"
 import { DefenseService } from "./DefenseService"
 import { isAppControlledPlayback } from "../lib/roomTypeHelpers"
+import { shouldAdvanceToNextQueueItem } from "../lib/playbackHelpers"
 
 function isSameMultiset(a: string[], b: string[]): boolean {
   if (a.length !== b.length) return false
@@ -564,9 +565,9 @@ export class DJService {
   }
 
   /**
-   * App-controlled: resume Spotify playback (unpause). Room creator or room admin only.
+   * App-controlled: read Spotify playback state for admin UI (play/pause toggle).
    */
-  async resumePlayback(roomId: string, userId: string) {
+  async getPlaybackState(roomId: string, userId: string) {
     const room = await findRoom({ context: this.context, roomId })
     if (!room) {
       return { success: false as const, message: "Room not found" }
@@ -585,7 +586,7 @@ export class DJService {
       roomCreator: room.creator,
     })
     if (!allowed) {
-      return { success: false as const, message: "Not authorized to resume playback" }
+      return { success: false as const, message: "Not authorized to read playback state" }
     }
 
     const playbackController = await this.adapterService.getRoomPlaybackController(roomId)
@@ -593,17 +594,106 @@ export class DJService {
       return { success: false as const, message: "No playback controller configured for this room" }
     }
 
+    const getPlayback = playbackController.api.getPlayback
+    if (!getPlayback) {
+      return { success: false as const, message: "Playback controller does not support reading state" }
+    }
+
     try {
-      await playbackController.api.play()
+      const playback = await getPlayback()
+      const trackId =
+        playback.track && typeof playback.track === "object" && "id" in playback.track
+          ? String((playback.track as { id: string }).id)
+          : null
+      return {
+        success: true as const,
+        state: playback.state,
+        trackId,
+      }
     } catch (e) {
-      console.error("[DJService.resumePlayback] play failed:", e)
+      console.error("[DJService.getPlaybackState] getPlayback failed:", e)
       return {
         success: false as const,
-        message: "Failed to resume playback on Spotify",
+        message: "Failed to read playback state from Spotify",
+      }
+    }
+  }
+
+  /**
+   * App-controlled: pause when playing; when paused, resume mid-track or start the next
+   * queued track if the previous song has finished. Room creator or room admin only.
+   */
+  async togglePlayback(roomId: string, userId: string) {
+    const room = await findRoom({ context: this.context, roomId })
+    if (!room) {
+      return { success: false as const, message: "Room not found" }
+    }
+    if (!isAppControlledPlayback(room)) {
+      return {
+        success: false as const,
+        message: "This action is only available in app-controlled playback mode",
       }
     }
 
-    return { success: true as const }
+    const allowed = await isRoomAdmin({
+      context: this.context,
+      roomId,
+      userId,
+      roomCreator: room.creator,
+    })
+    if (!allowed) {
+      return { success: false as const, message: "Not authorized to control playback" }
+    }
+
+    const playbackController = await this.adapterService.getRoomPlaybackController(roomId)
+    if (!playbackController) {
+      return { success: false as const, message: "No playback controller configured for this room" }
+    }
+
+    const api = playbackController.api
+    const getPlayback = api.getPlayback
+    if (!getPlayback) {
+      return { success: false as const, message: "Playback controller does not support reading state" }
+    }
+
+    try {
+      const playback = await getPlayback()
+
+      if (playback.state === "playing") {
+        await api.pause()
+        return { success: true as const, state: "paused" as const, action: "paused" as const }
+      }
+
+      const queue = await getQueue({ context: this.context, roomId })
+      if (
+        shouldAdvanceToNextQueueItem(playback, queue, {
+          queueAutoAdvance: room.queueAutoAdvance !== false,
+        })
+      ) {
+        const nextItem = queue.find((item) => !item.locked)
+        if (nextItem) {
+          const playResult = await this.playQueuedTrack(roomId, userId, nextItem.track.id)
+          if (!playResult.success) {
+            return playResult
+          }
+          return {
+            success: true as const,
+            state: "playing" as const,
+            action: "advanced" as const,
+            trackTitle: playResult.trackTitle,
+          }
+        }
+      }
+
+      await api.play()
+      return { success: true as const, state: "playing" as const, action: "resumed" as const }
+    } catch (e) {
+      console.error("[DJService.togglePlayback] failed:", e)
+      return {
+        success: false as const,
+        message: "Failed to control playback on Spotify",
+      }
+    }
   }
 
   /**

--- a/packages/types/PlaybackController.ts
+++ b/packages/types/PlaybackController.ts
@@ -22,6 +22,8 @@ export interface PlaybackControllerApi {
   getPlayback: () => Promise<{
     state: PlaybackState
     track: PlaybackControllerQueueItem | null
+    progressMs?: number | null
+    durationMs?: number | null
   }>
   play: () => Promise<void>
   /** Start playback of a specific track URI on the active device (e.g. Spotify resource URI). */

--- a/packages/types/Room.ts
+++ b/packages/types/Room.ts
@@ -66,6 +66,8 @@ export type Room = {
   // Queue display settings (default true)
   showQueueCount?: boolean
   showQueueTracks?: boolean
+  /** App-controlled only. When false, admins advance manually; default true. */
+  queueAutoAdvance?: boolean
   // Chat settings
   /** When true, non-admin listeners may upload images in chat; room admins may always upload. */
   allowChatImages?: boolean
@@ -102,6 +104,7 @@ export interface StoredRoom
     | "metadataSourceIds"
     | "showQueueCount"
     | "showQueueTracks"
+    | "queueAutoAdvance"
     | "allowChatImages"
     | "showSchedulePublic"
     | "announceActiveSegment"
@@ -116,6 +119,7 @@ export interface StoredRoom
   persistent?: Bool
   showQueueCount?: Bool
   showQueueTracks?: Bool
+  queueAutoAdvance?: Bool
   allowChatImages?: Bool
   showSchedulePublic?: Bool
   announceActiveSegment?: Bool

--- a/packages/types/Scheduling.ts
+++ b/packages/types/Scheduling.ts
@@ -13,6 +13,7 @@ export type SegmentRoomSettingsOverride = {
   deputizeOnJoin?: boolean
   showQueueCount?: boolean
   showQueueTracks?: boolean
+  queueAutoAdvance?: boolean
   fetchMeta?: boolean
   announceNowPlaying?: boolean
   playbackMode?: "spotify-controlled" | "app-controlled"


### PR DESCRIPTION
In App-controlled queue mode:

- Adds ability to toggle whether playback automatically resumes after a queue track is finished playing
- Adds a play/pause button to toggle playback state of the MediaSource, or start playing the next track 