### PR TITLE
Queue Split

### DIFF
--- a/apps/game-studio/src/studio/bridgeClient.ts
+++ b/apps/game-studio/src/studio/bridgeClient.ts
@@ -38,6 +38,8 @@ export type StudioBridgeSnapshot = {
   storedArtifacts: StoredArtifactPublic[]
   activePoll?: Poll | null
   pollHistory?: PollHistoryEntry[]
+  /** App-controlled queue split anchor (canonical key of first track below divider). */
+  splitKey?: string | null
 }
 
 export function serializeStudioRoom(room: StudioRoom): StudioBridgeSnapshot {

--- a/apps/studio-bridge/src/payloads.ts
+++ b/apps/studio-bridge/src/payloads.ts
@@ -197,6 +197,7 @@ export function buildInitPayload(snap: BridgeSnapshot, self: User) {
     passwordRequired: false,
     playlist: [] as unknown[],
     queue: snap.queue,
+    splitKey: snap.splitKey ?? null,
     reactions: {
       message: {} as Record<string, unknown[]>,
       track: {} as Record<string, unknown[]>,

--- a/apps/studio-bridge/src/server.ts
+++ b/apps/studio-bridge/src/server.ts
@@ -5,6 +5,8 @@ import type { Socket } from "socket.io"
 import type { Server as IOServer } from "socket.io"
 import { Server } from "socket.io"
 import type { User } from "@repo/types/User"
+import { canonicalQueueTrackKey } from "@repo/types/Queue"
+import type { QueueItem } from "@repo/types/Queue"
 
 import type { BridgeSnapshot } from "./types.js"
 import {
@@ -50,6 +52,35 @@ function pollPreviewEnabled(socket: Socket): boolean {
 function bridgeRoomTimestampIso(): string {
   const ms = getLastSyncEpochMs()
   return ms > 0 ? new Date(ms).toISOString() : BRIDGE_PRE_SYNC_ISO
+}
+
+function normalizeSplitKey(
+  queue: QueueItem[],
+  splitKey: string | null | undefined,
+): string | null {
+  if (!splitKey) return null
+  const playable = queue.filter((item) => !item.locked)
+  const index = playable.findIndex((item) => canonicalQueueTrackKey(item) === splitKey)
+  if (index <= 0) return null
+  return splitKey
+}
+
+function withNormalizedSplitKey(snap: BridgeSnapshot): BridgeSnapshot {
+  return {
+    ...snap,
+    splitKey: normalizeSplitKey(snap.queue, snap.splitKey),
+  }
+}
+
+function emitQueueChanged(io: IOServer, roomId: string, snap: BridgeSnapshot): void {
+  io.to(roomSocketPath(roomId)).emit("event", {
+    type: "QUEUE_CHANGED",
+    data: {
+      roomId,
+      queue: snap.queue,
+      splitKey: snap.splitKey ?? null,
+    },
+  })
 }
 
 /** Updates socket identity and pushes INIT + USER_GAME_STATE (same contract as socket VIEW_AS_USER). */
@@ -162,10 +193,7 @@ function broadcastRefresh(io: IOServer, roomId: string): void {
   }
 
   if (sameRoom && prevSnap && queueChanged(prevSnap, snap)) {
-    io.to(roomPath).emit("event", {
-      type: "QUEUE_CHANGED",
-      data: { roomId, queue: snap.queue },
-    })
+    emitQueueChanged(io, roomId, snap)
   }
 
   void io.in(roomPath).fetchSockets().then((sockets) => {
@@ -698,6 +726,67 @@ function wireSocketHandlers(io: IOServer): void {
       /** Success/failure is emitted by Game Studio via POST `/preview/queue-remove-result`. */
     })
 
+    socket.on("SET_QUEUE_SPLIT", async (data: { belowKey?: string }) => {
+      const roomId = socket.data.roomId as string | undefined
+      const userId = socket.data.userId as string | undefined
+      const belowKey = typeof data?.belowKey === "string" ? data.belowKey : undefined
+      const snap = getBridgeSnapshot()
+      if (!roomId || !userId || !belowKey || !snap || snap.roomId !== roomId) {
+        socket.emit("event", {
+          type: "SET_QUEUE_SPLIT_FAILURE",
+          data: { message: "Not in a room or missing split position." },
+        })
+        return
+      }
+      const roomUser = snap.users.find((u) => u.userId === userId)
+      if (!roomUser?.isAdmin) {
+        socket.emit("event", {
+          type: "SET_QUEUE_SPLIT_FAILURE",
+          data: { message: "Not authorized to set the queue split" },
+        })
+        return
+      }
+      const playable = snap.queue.filter((item) => !item.locked)
+      const index = playable.findIndex((item) => canonicalQueueTrackKey(item) === belowKey)
+      if (index < 0) {
+        socket.emit("event", {
+          type: "SET_QUEUE_SPLIT_FAILURE",
+          data: { message: "Invalid queue split position" },
+        })
+        return
+      }
+      const nextSplitKey = index === 0 ? null : belowKey
+      const nextSnap = withNormalizedSplitKey({ ...snap, splitKey: nextSplitKey })
+      setBridgeSnapshot(nextSnap)
+      socket.emit("event", { type: "SET_QUEUE_SPLIT_SUCCESS" })
+      emitQueueChanged(io, roomId, nextSnap)
+    })
+
+    socket.on("REMOVE_QUEUE_SPLIT", async () => {
+      const roomId = socket.data.roomId as string | undefined
+      const userId = socket.data.userId as string | undefined
+      const snap = getBridgeSnapshot()
+      if (!roomId || !userId || !snap || snap.roomId !== roomId) {
+        socket.emit("event", {
+          type: "REMOVE_QUEUE_SPLIT_FAILURE",
+          data: { message: "Not in a room." },
+        })
+        return
+      }
+      const roomUser = snap.users.find((u) => u.userId === userId)
+      if (!roomUser?.isAdmin) {
+        socket.emit("event", {
+          type: "REMOVE_QUEUE_SPLIT_FAILURE",
+          data: { message: "Not authorized to remove the queue split" },
+        })
+        return
+      }
+      const nextSnap = withNormalizedSplitKey({ ...snap, splitKey: null })
+      setBridgeSnapshot(nextSnap)
+      socket.emit("event", { type: "REMOVE_QUEUE_SPLIT_SUCCESS" })
+      emitQueueChanged(io, roomId, nextSnap)
+    })
+
     socket.on(
       "EXECUTE_PLUGIN_ACTION",
       async (data: {
@@ -1171,7 +1260,15 @@ app.post("/sync", (req, res) => {
     res.status(400).json({ error: "Invalid BridgeSnapshot body" })
     return
   }
-  setBridgeSnapshot(parsed)
+  const prev = getBridgeSnapshot()
+  const merged: BridgeSnapshot =
+    parsed.splitKey !== undefined
+      ? parsed
+      : {
+          ...parsed,
+          splitKey: prev?.roomId === parsed.roomId ? (prev.splitKey ?? null) : null,
+        }
+  setBridgeSnapshot(withNormalizedSplitKey(merged))
   res.status(204).end()
   if (io) {
     broadcastRefresh(io, parsed.roomId)

--- a/apps/studio-bridge/src/snapshotStore.ts
+++ b/apps/studio-bridge/src/snapshotStore.ts
@@ -16,6 +16,7 @@ function fingerprintSnapshot(s: BridgeSnapshot): string {
     roomId: s.roomId,
     chat: s.chat,
     queue: s.queue,
+    splitKey: s.splitKey ?? null,
     users: s.users,
     userStates: s.userStates,
     inventories: s.inventories,
@@ -67,8 +68,9 @@ export function queueHeadTrackId(s: BridgeSnapshot | null): string | null {
   return id ?? null
 }
 
-/** True when the ordered queue (length or any position’s track id) differs. */
+/** True when the ordered queue (length or any position’s track id) or split anchor differs. */
 export function queueChanged(prev: BridgeSnapshot, next: BridgeSnapshot): boolean {
+  if ((prev.splitKey ?? null) !== (next.splitKey ?? null)) return true
   if (prev.queue.length !== next.queue.length) return true
   for (let i = 0; i < prev.queue.length; i++) {
     const a = prev.queue[i]?.mediaSource?.trackId ?? null

--- a/apps/studio-bridge/src/types.ts
+++ b/apps/studio-bridge/src/types.ts
@@ -32,4 +32,6 @@ export type BridgeSnapshot = {
     segmentTitle: string
     count: number
   } | null
+  /** App-controlled queue split anchor (canonical key of first track below divider). */
+  splitKey?: string | null
 }

--- a/apps/web/src/components/QueuedTracksSection.tsx
+++ b/apps/web/src/components/QueuedTracksSection.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useRef, useCallback, memo, useState, useEffect } from "react"
+import { useMemo, useRef, useCallback, memo, useState, useEffect, Fragment } from "react"
 import {
   Box,
+  Button,
   Heading,
   HStack,
   Badge,
@@ -10,6 +11,7 @@ import {
   ScrollArea,
   Checkbox,
   IconButton,
+  Group,
 } from "@chakra-ui/react"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { DragDropProvider, DragOverlay } from "@dnd-kit/react"
@@ -18,10 +20,18 @@ import { isSortable } from "@dnd-kit/react/sortable"
 import { move } from "@dnd-kit/helpers"
 import { canonicalQueueTrackKey, type QueueItem as SharedQueueItem } from "@repo/types/Queue"
 import { GripVertical } from "lucide-react"
-import { LuPlay, LuPause } from "react-icons/lu"
+import {
+  LuPlay,
+  LuPause,
+  LuX,
+  LuSquareSplitVertical,
+  LuArrowUpToLine,
+  LuArrowUp,
+} from "react-icons/lu"
 import { QueueItem } from "../types/Queue"
 import {
   useQueueList,
+  useQueueSplitKey,
   useCurrentRoom,
   useIsAdmin,
   useIsRoomCreator,
@@ -41,10 +51,126 @@ const MAX_LIST_HEIGHT = 200
 type SpotifyPlaybackState = "playing" | "paused" | "stopped"
 
 export const ROOM_QUEUE_SORTABLE_GROUP = "room-queue"
+export const QUEUE_SPLIT_DIVIDER_ID = "queue-split-divider"
 
 function toCanonicalKey(item: QueueItem): string {
   return canonicalQueueTrackKey(item as unknown as SharedQueueItem)
 }
+
+function buildSortableOrder(
+  orderedKeys: string[],
+  splitKey: string | null,
+  includeDivider: boolean,
+): string[] {
+  if (!includeDivider || !splitKey) return orderedKeys
+  const splitIndex = orderedKeys.indexOf(splitKey)
+  if (splitIndex === -1) return orderedKeys
+  return [
+    ...orderedKeys.slice(0, splitIndex),
+    QUEUE_SPLIT_DIVIDER_ID,
+    ...orderedKeys.slice(splitIndex),
+  ]
+}
+
+function listenForSocketAck(
+  successType: string,
+  failureType: string,
+  onFailure: (message?: string) => void,
+) {
+  let timeoutId: number
+  const onEvent = (payload: { type?: string; data?: { message?: string } }) => {
+    if (payload.type === successType) {
+      socket.off("event", onEvent)
+      window.clearTimeout(timeoutId)
+    }
+    if (payload.type === failureType) {
+      socket.off("event", onEvent)
+      window.clearTimeout(timeoutId)
+      onFailure(payload.data?.message)
+    }
+  }
+  socket.on("event", onEvent)
+  timeoutId = window.setTimeout(() => socket.off("event", onEvent), 10000)
+}
+
+const QueueSplitDivider = memo(function QueueSplitDivider({
+  onRemove,
+  dragHandleRef,
+  isDragging,
+}: {
+  onRemove?: () => void
+  dragHandleRef?: (element: Element | null) => void
+  isDragging?: boolean
+}) {
+  return (
+    <HStack
+      gap={2}
+      w="100%"
+      py={1}
+      px={2}
+      borderRadius="md"
+      borderWidth="1px"
+      borderStyle="dashed"
+      borderColor="primary.emphasized"
+      bg="primary.subtle/30"
+      opacity={isDragging ? 0.5 : 1}
+      aria-label="Queue split"
+    >
+      {dragHandleRef ? (
+        <Box
+          ref={dragHandleRef}
+          cursor="grab"
+          color="fg.muted"
+          flexShrink={0}
+          aria-label="Move queue split"
+        >
+          <GripVertical size={18} />
+        </Box>
+      ) : null}
+      <HStack width="100%" color="primary.solid">
+        <Separator borderColor="primary.solid" flex="1" />
+        <LuArrowUp />
+        <Text fontSize="2xs" color="primary.solid">
+          Queue split — new tracks go above
+        </Text>
+        <LuArrowUp />
+        <Separator borderColor="primary.solid" flex="1" />
+      </HStack>
+      {onRemove ? (
+        <IconButton
+          aria-label="Remove queue split"
+          variant="ghost"
+          size="xs"
+          colorPalette="primary"
+          onClick={onRemove}
+        >
+          <LuX />
+        </IconButton>
+      ) : null}
+    </HStack>
+  )
+})
+
+const SortableQueueSplitDivider = memo(function SortableQueueSplitDivider({
+  index,
+  onRemove,
+}: {
+  index: number
+  onRemove: () => void
+}) {
+  const { ref, handleRef, isDragging } = useSortable({
+    id: QUEUE_SPLIT_DIVIDER_ID,
+    index,
+    group: ROOM_QUEUE_SORTABLE_GROUP,
+    data: { type: "queue-split-divider" as const },
+  })
+
+  return (
+    <Box ref={ref} w="100%">
+      <QueueSplitDivider onRemove={onRemove} dragHandleRef={handleRef} isDragging={isDragging} />
+    </Box>
+  )
+})
 
 const LockedQueueRow = memo(function LockedQueueRow({
   item,
@@ -129,6 +255,7 @@ function QueueDragPreview({
 
 function QueuedTracksSection() {
   const queue: QueueItem[] = useQueueList()
+  const splitKey = useQueueSplitKey()
   const room = useCurrentRoom()
   const viewportRef = useRef<HTMLDivElement | null>(null)
   const isAdmin = useIsAdmin()
@@ -224,36 +351,100 @@ function QueuedTracksSection() {
     [queue],
   )
 
+  const sortableOrder = useMemo(
+    () => buildSortableOrder(orderedKeys, splitKey, canReorder),
+    [orderedKeys, splitKey, canReorder],
+  )
+
   const hasSortableItems = orderedKeys.length > 0
+  const showAddSplit = canReorder && isAppControlled && !splitKey && orderedKeys.length >= 2
+
+  const handleRemoveSplit = useCallback(() => {
+    listenForSocketAck("REMOVE_QUEUE_SPLIT_SUCCESS", "REMOVE_QUEUE_SPLIT_FAILURE", (message) => {
+      toast({
+        title: "Couldn't remove queue split",
+        description: message,
+        type: "error",
+        duration: 4000,
+      })
+    })
+    emitToSocket("REMOVE_QUEUE_SPLIT", {})
+  }, [])
+
+  const handleAddSplit = useCallback(() => {
+    const belowKey = orderedKeys[1]
+    if (!belowKey) return
+    listenForSocketAck("SET_QUEUE_SPLIT_SUCCESS", "SET_QUEUE_SPLIT_FAILURE", (message) => {
+      toast({
+        title: "Couldn't add queue split",
+        description: message,
+        type: "error",
+        duration: 4000,
+      })
+    })
+    emitToSocket("SET_QUEUE_SPLIT", { belowKey })
+  }, [orderedKeys])
 
   const handleDragEnd = useCallback(
     (event: { canceled?: boolean } & Parameters<typeof move>[1]) => {
       if (event.canceled) return
-      const newKeys = move(orderedKeys, event)
-      if (JSON.stringify(newKeys) === JSON.stringify(orderedKeys)) return
 
-      let timeoutId: number
-      const onEvent = (payload: { type?: string; data?: { message?: string } }) => {
-        if (payload.type === "REORDER_QUEUE_SUCCESS") {
-          socket.off("event", onEvent)
-          window.clearTimeout(timeoutId)
+      const sourceId = String(event.operation?.source?.id ?? "")
+
+      if (sourceId === QUEUE_SPLIT_DIVIDER_ID) {
+        const newOrder = move(sortableOrder, event) as string[]
+        if (JSON.stringify(newOrder) === JSON.stringify(sortableOrder)) return
+
+        const dividerIndex = newOrder.indexOf(QUEUE_SPLIT_DIVIDER_ID)
+        const belowKey = newOrder[dividerIndex + 1]
+
+        if (dividerIndex <= 0 || !belowKey || belowKey === QUEUE_SPLIT_DIVIDER_ID) {
+          listenForSocketAck(
+            "REMOVE_QUEUE_SPLIT_SUCCESS",
+            "REMOVE_QUEUE_SPLIT_FAILURE",
+            (message) => {
+              toast({
+                title: "Couldn't remove queue split",
+                description: message,
+                type: "error",
+                duration: 4000,
+              })
+            },
+          )
+          emitToSocket("REMOVE_QUEUE_SPLIT", {})
+          return
         }
-        if (payload.type === "REORDER_QUEUE_FAILURE") {
-          socket.off("event", onEvent)
-          window.clearTimeout(timeoutId)
+
+        if (belowKey === splitKey) return
+
+        listenForSocketAck("SET_QUEUE_SPLIT_SUCCESS", "SET_QUEUE_SPLIT_FAILURE", (message) => {
           toast({
-            title: "Couldn't reorder queue",
-            description: payload.data?.message,
+            title: "Couldn't move queue split",
+            description: message,
             type: "error",
             duration: 4000,
           })
-        }
+        })
+        emitToSocket("SET_QUEUE_SPLIT", { belowKey })
+        return
       }
-      socket.on("event", onEvent)
-      timeoutId = window.setTimeout(() => socket.off("event", onEvent), 10000)
-      emitToSocket("REORDER_QUEUE", { orderedKeys: newKeys as string[] })
+
+      const newKeys = (move(sortableOrder, event) as string[]).filter(
+        (id) => id !== QUEUE_SPLIT_DIVIDER_ID,
+      )
+      if (JSON.stringify(newKeys) === JSON.stringify(orderedKeys)) return
+
+      listenForSocketAck("REORDER_QUEUE_SUCCESS", "REORDER_QUEUE_FAILURE", (message) => {
+        toast({
+          title: "Couldn't reorder queue",
+          description: message,
+          type: "error",
+          duration: 4000,
+        })
+      })
+      emitToSocket("REORDER_QUEUE", { orderedKeys: newKeys })
     },
-    [orderedKeys],
+    [sortableOrder, orderedKeys, splitKey],
   )
 
   const queueAutoAdvance = room?.queueAutoAdvance !== false
@@ -291,23 +482,31 @@ function QueuedTracksSection() {
   const virtualItems = virtualizer.getVirtualItems()
 
   const playbackMode = room?.playbackMode
+  const dividerSortableIndex = sortableOrder.indexOf(QUEUE_SPLIT_DIVIDER_ID)
 
   const sortableList =
     queue.length > 0 ? (
       <VStack gap={2} w="100%" align="stretch" pb={2}>
-        {queue.map((item, i) => {
+        {queue.map((item) => {
           const key = toCanonicalKey(item)
           if (item.locked) {
             return <LockedQueueRow key={key} item={item} playbackMode={playbackMode} />
           }
-          const sortableIndex = queue.slice(0, i).filter((x) => !x.locked).length
+          const showSplitAbove = splitKey === key
           return (
-            <SortableQueueRow
-              key={key}
-              item={item}
-              index={sortableIndex}
-              playbackMode={playbackMode}
-            />
+            <Fragment key={key}>
+              {showSplitAbove && canReorder && dividerSortableIndex !== -1 ? (
+                <SortableQueueSplitDivider
+                  index={dividerSortableIndex}
+                  onRemove={handleRemoveSplit}
+                />
+              ) : null}
+              <SortableQueueRow
+                item={item}
+                index={sortableOrder.indexOf(key)}
+                playbackMode={playbackMode}
+              />
+            </Fragment>
           )
         })}
       </VStack>
@@ -332,6 +531,9 @@ function QueuedTracksSection() {
               transform={`translateY(${virtualRow.start}px)`}
             >
               <VStack pb={2} gap={2} w="100%" align="stretch">
+                {splitKey === toCanonicalKey(item) ? (
+                  <QueueSplitDivider onRemove={canReorder ? handleRemoveSplit : undefined} />
+                ) : null}
                 <PlaylistItem item={item} isQueueItem playbackMode={playbackMode} />
                 {virtualRow.index < virtualRowCount - 1 && (
                   <Separator borderColor="secondaryBorder" opacity={0.5} />
@@ -353,6 +555,9 @@ function QueuedTracksSection() {
           {(source) => {
             if (!source || !isSortable(source)) return null
             const sid = String(source.id)
+            if (sid === QUEUE_SPLIT_DIVIDER_ID) {
+              return <QueueSplitDivider isDragging />
+            }
             const rowItem = queue.find((q) => !q.locked && toCanonicalKey(q) === sid)
             if (!rowItem) return null
             return <QueueDragPreview item={rowItem} playbackMode={playbackMode} />
@@ -368,15 +573,14 @@ function QueuedTracksSection() {
   const badgeCount = virtualRowCount
 
   const showMusicPlayDisabled =
-    playbackTogglePending ||
-    (spotifyPlaybackState !== "playing" && queue.length === 0)
+    playbackTogglePending || (spotifyPlaybackState !== "playing" && queue.length === 0)
 
   const showMusicPlaybackTooltip =
     spotifyPlaybackState === "playing"
       ? "Pause show music playback on Spotify"
       : queue.length === 0
-        ? "Nothing in the queue to play"
-        : "Resume show music or start the next queued track"
+      ? "Nothing in the queue to play"
+      : "Resume show music or start the next queued track"
 
   return (
     <Box
@@ -444,6 +648,11 @@ function QueuedTracksSection() {
                   </IconButton>
                 </Box>
               </Tooltip>
+            )}
+            {showAddSplit && (
+              <Button variant="outline" colorPalette="primary" size="xs" onClick={handleAddSplit}>
+                <LuSquareSplitVertical />
+              </Button>
             )}
             <ButtonAddToQueue variant="solid" colorPalette="primary" size="xs" showCount={false} />
           </HStack>

--- a/apps/web/src/components/QueuedTracksSection.tsx
+++ b/apps/web/src/components/QueuedTracksSection.tsx
@@ -650,9 +650,17 @@ function QueuedTracksSection() {
               </Tooltip>
             )}
             {showAddSplit && (
-              <Button variant="outline" colorPalette="primary" size="xs" onClick={handleAddSplit}>
-                <LuSquareSplitVertical />
-              </Button>
+              <Tooltip content="Add queue split" positioning={{ placement: "top" }}>
+                <Button
+                  variant="outline"
+                  colorPalette="primary"
+                  size="xs"
+                  onClick={handleAddSplit}
+                  aria-label="Add queue split"
+                >
+                  <LuSquareSplitVertical />
+                </Button>
+              </Tooltip>
             )}
             <ButtonAddToQueue variant="solid" colorPalette="primary" size="xs" showCount={false} />
           </HStack>

--- a/apps/web/src/hooks/useActors.ts
+++ b/apps/web/src/hooks/useActors.ts
@@ -217,6 +217,10 @@ export const useQueueList = (): QueueItem[] => {
   return useSelector(queueListActor, (s) => s.context.queue)
 }
 
+export const useQueueSplitKey = (): string | null => {
+  return useSelector(queueListActor, (s) => s.context.splitKey)
+}
+
 export const useQueueCount = () => {
   return useSelector(queueListActor, (s) => s.context.queue.length)
 }

--- a/apps/web/src/machines/queueListMachine.ts
+++ b/apps/web/src/machines/queueListMachine.ts
@@ -8,6 +8,7 @@ import { subscribeById, unsubscribeById } from "../actors/socketActor"
 
 export interface QueueListContext {
   queue: QueueItem[]
+  splitKey: string | null
   subscriptionId: string | null
 }
 
@@ -16,9 +17,9 @@ type QueueListEvent =
   | { type: "DEACTIVATE" }
   | {
       type: "INIT"
-      data: { queue?: QueueItem[] }
+      data: { queue?: QueueItem[]; splitKey?: string | null }
     }
-  | { type: "QUEUE_CHANGED"; data: { queue: QueueItem[] } }
+  | { type: "QUEUE_CHANGED"; data: { queue: QueueItem[]; splitKey?: string | null } }
 
 // ============================================================================
 // Machine
@@ -44,12 +45,16 @@ export const queueListMachine = setup({
     },
     applySocketQueue: assign(({ event }) => {
       if (event.type === "INIT" || event.type === "QUEUE_CHANGED") {
-        return { queue: event.data.queue ?? [] }
+        return {
+          queue: event.data.queue ?? [],
+          splitKey: event.data.splitKey ?? null,
+        }
       }
       return {}
     }),
     resetQueue: assign({
       queue: () => [],
+      splitKey: () => null,
       subscriptionId: () => null,
     }),
   },
@@ -58,6 +63,7 @@ export const queueListMachine = setup({
   initial: "idle",
   context: {
     queue: [],
+    splitKey: null,
     subscriptionId: null,
   },
   states: {

--- a/docs/adrs/0067-queue-split-reserved-segment.md
+++ b/docs/adrs/0067-queue-split-reserved-segment.md
@@ -1,0 +1,42 @@
+# 0067. Queue split for reserved lower segment (app-controlled)
+
+**Date:** 2026-07-03  
+**Status:** Accepted
+
+## Context
+
+App-controlled playback ([ADR 0040](0040-app-controlled-playback-and-ordered-queue.md)) gives the app an ordered Redis queue suitable for reorder ([ADR 0041](0041-queue-drag-reorder-authorization.md)). Show hosts sometimes want to **pivot** the upper queue toward a themed segment while **preserving** tracks already scheduled below — without manually shuffling or losing the lower block.
+
+An integer index for the divider would require maintenance on every reorder, shuffle, and removal. Split state must stay consistent across all `QUEUE_CHANGED` emit paths and reconnect (`INIT`).
+
+## Decision
+
+1. **Scope:** Queue split applies only when `Room.playbackMode === "app-controlled"`. Non-app-controlled rooms never store or broadcast split state.
+
+2. **Storage:** One Redis string per room: `room:{roomId}:queue_split` = `belowKey`, a `canonicalQueueTrackKey` for the **first track below the divider**. The divider renders **above** the row whose canonical key equals `belowKey`. Absent key means no split. Only one split per room.
+
+3. **Normalize on send:** Before every `QUEUE_CHANGED` and app-controlled `INIT`, `getNormalizedQueueSplit` loads the key and current `getQueue` (unlocked rows only for index math). If `belowKey` is missing from the queue or is at index **0** (nothing above it), clear Redis and return `null`. All emit sites use shared `buildQueueChangedData` so drain and reorder stay consistent without per-path arithmetic.
+
+4. **Re-anchor on removal:** When the anchor track is removed via `removeFromQueue`, re-anchor **before** `ZREM`: if the removed key is the split anchor, set split to the successor in `queue_order` or clear if none. Head drains via `ZPOPMIN` do not re-anchor; normalization clears the split when the anchor reaches index 0.
+
+5. **Split-aware enqueue:** In `DJService.queueSongAs`, after `addToQueue`, if app-controlled and a normalized split exists, splice the new item immediately **before** `belowKey` and `setQueue`. `belowKey` is unchanged; each add pushes the divider down visually.
+
+6. **Authorization:** Same gate as queue reorder ([ADR 0041](0041-queue-drag-reorder-authorization.md)): room admins only (`userCanReorderQueueInRoom` / `useCanReorderQueue`). **All viewers** see the divider; only admins add, drag, or remove it.
+
+7. **Socket contract:** Clients emit `SET_QUEUE_SPLIT` `{ belowKey: string }` and `REMOVE_QUEUE_SPLIT` `{}`. Handlers ack `*_SUCCESS` / `*_FAILURE` on the requesting socket; applied state arrives via `QUEUE_CHANGED`. Setting split with `belowKey` at index 0 clears the split (same as remove).
+
+8. **Wire payload:** `QUEUE_CHANGED` and app-controlled `INIT` include `splitKey: string | null` alongside `queue`. `clearQueue` clears split state.
+
+9. **Client UX:** `queueListMachine` holds `splitKey`. `QueuedTracksSection` renders a divider above the anchor row for everyone; admins get a sortable sentinel (`queue-split-divider`) in the same DnD group as queue rows. Divider drag emits split events; track drag emits `REORDER_QUEUE` with track keys only.
+
+10. **Game Studio preview:** `studio-bridge` stores optional `splitKey` on `BridgeSnapshot`, echoes split socket handlers locally, and includes `splitKey` in INIT / `QUEUE_CHANGED` so `make game-studio` preview stays aligned.
+
+## Consequences
+
+- **Themed pivots without losing the tail:** New requests land in the upper segment; the lower block stays reserved until played or manually reordered.
+- **Anchor stability:** Reorder and shuffle move the divider with its anchor track; no index counter in Redis.
+- **Automatic cleanup:** Draining the upper section removes the split when normalization sees index 0 — no orphan divider at the head.
+- **Single split limit:** Multiple reserved bands would need a new model (list of anchors or segments).
+- **Bridge parity:** Split in preview is bridge-local state; Game Studio sandbox queue mutations do not model split-aware enqueue unless extended later.
+
+See also: [0040](0040-app-controlled-playback-and-ordered-queue.md), [0041](0041-queue-drag-reorder-authorization.md), [0014](0014-emit-domain-events-from-operations-only.md), [0013](0013-track-identity-media-and-metadata-sources.md), [0051](0051-game-studio-client-sandbox.md).

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -72,6 +72,7 @@ This directory contains Architectural Decision Records (ADRs) for the Listening 
 | [0064](0064-radio-app-controlled-playback-default.md) | App-controlled playback default for new radio rooms | Accepted |
 | [0065](0065-email-newsletter-via-resend.md) | Email newsletter via Resend (subscribers, broadcasts, webhooks) | Superseded by [0066](0066-email-newsletter-via-amazon-ses.md) |
 | [0066](0066-email-newsletter-via-amazon-ses.md) | Email newsletter via Amazon SES (own-list send, SNS suppression, Redis scheduling) | Accepted |
+| [0067](0067-queue-split-reserved-segment.md) | Queue split for reserved lower segment (app-controlled) | Accepted |
 
 ## Creating a New ADR
 

--- a/packages/adapter-spotify/lib/queueSyncJob.ts
+++ b/packages/adapter-spotify/lib/queueSyncJob.ts
@@ -40,7 +40,9 @@ export function createQueueSyncJob(params: {
     handler: async ({ api }: { api: JobApi; context: AppContext }) => {
       try {
         // Dynamic imports to avoid circular dependencies
-        const { findRoom, getQueue, removeFromQueue } = await import("@repo/server/operations/data")
+        const { findRoom, getQueue, removeFromQueue, buildQueueChangedData } = await import(
+          "@repo/server/operations/data"
+        )
         const { isAppControlledPlayback } = await import("@repo/server/lib/roomTypeHelpers")
         const { AdapterService } = await import("@repo/server/services/AdapterService")
 
@@ -100,11 +102,12 @@ export function createQueueSyncJob(params: {
 
         // Emit QUEUE_CHANGED event
         if (context.systemEvents) {
-          const updatedQueue = await getQueue({ context, roomId })
-          await context.systemEvents.emit(roomId, "QUEUE_CHANGED", {
+          const payload = await buildQueueChangedData({
             roomId,
-            queue: updatedQueue,
+            context,
+            appControlled: false,
           })
+          await context.systemEvents.emit(roomId, "QUEUE_CHANGED", payload)
         }
 
         console.log(

--- a/packages/adapter-spotify/lib/trackAdvanceJob.ts
+++ b/packages/adapter-spotify/lib/trackAdvanceJob.ts
@@ -56,11 +56,11 @@ export function createTrackAdvanceJob(params: {
         const { findRoom } = await import("@repo/server/operations/data")
         const {
           addToQueue,
+          buildQueueChangedData,
           clearDispatchedTrack,
           popNextFromQueue,
           getDispatchedTrack,
           setDispatchedTrack,
-          getQueueWithDispatched,
         } = await import("@repo/server/operations/data")
         const { isAppControlledPlayback, isQueueAutoAdvanceEnabled } = await import("@repo/server/lib/roomTypeHelpers")
         const {
@@ -170,13 +170,14 @@ export function createTrackAdvanceJob(params: {
           return
         }
 
-        const updatedQueue = await getQueueWithDispatched({ context, roomId })
+        const updatedQueue = await buildQueueChangedData({
+          roomId,
+          context,
+          appControlled: true,
+        })
 
         if (context.systemEvents) {
-          await context.systemEvents.emit(roomId, "QUEUE_CHANGED", {
-            roomId,
-            queue: updatedQueue,
-          })
+          await context.systemEvents.emit(roomId, "QUEUE_CHANGED", updatedQueue)
         }
       } catch (error: unknown) {
         const err = error as { status?: number; message?: string }

--- a/packages/server/controllers/djController.ts
+++ b/packages/server/controllers/djController.ts
@@ -134,6 +134,14 @@ export function createDJController(socket: SocketWithContext, io: Server): void 
     await handlers.reorderQueue(connections, payload)
   })
 
+  socket.on("SET_QUEUE_SPLIT", async (payload: { belowKey: string }) => {
+    await handlers.setQueueSplit(connections, payload)
+  })
+
+  socket.on("REMOVE_QUEUE_SPLIT", async () => {
+    await handlers.removeQueueSplit(connections)
+  })
+
   socket.on("TOGGLE_PLAYBACK", async () => {
     await handlers.togglePlayback(connections)
   })

--- a/packages/server/handlers/adminHandlersAdapter.test.ts
+++ b/packages/server/handlers/adminHandlersAdapter.test.ts
@@ -6,6 +6,13 @@ import { User } from "@repo/types/User"
 import { Room } from "@repo/types/Room"
 import { roomFactory, userFactory } from "@repo/factories"
 
+const dataMocks = vi.hoisted(() => ({
+  findRoom: vi.fn(),
+  getRoomUsers: vi.fn(),
+  removeOnlineUser: vi.fn(),
+  buildQueueChangedData: vi.fn(),
+}))
+
 // Mock dependencies
 vi.mock("../services/AdminService")
 vi.mock("../operations/data/pluginConfigs", () => ({
@@ -14,9 +21,10 @@ vi.mock("../operations/data/pluginConfigs", () => ({
   setPluginConfig: vi.fn().mockResolvedValue(undefined),
 }))
 vi.mock("../operations/data", () => ({
-  findRoom: vi.fn().mockResolvedValue(null),
-  getRoomUsers: vi.fn().mockResolvedValue([]),
-  removeOnlineUser: vi.fn().mockResolvedValue(undefined),
+  findRoom: dataMocks.findRoom,
+  getRoomUsers: dataMocks.getRoomUsers,
+  removeOnlineUser: dataMocks.removeOnlineUser,
+  buildQueueChangedData: dataMocks.buildQueueChangedData,
 }))
 
 describe("AdminHandlers", () => {
@@ -80,6 +88,15 @@ describe("AdminHandlers", () => {
     }
 
     adminHandlers = new AdminHandlers(adminService)
+
+    dataMocks.findRoom.mockResolvedValue(mockRoom)
+    dataMocks.getRoomUsers.mockResolvedValue([])
+    dataMocks.removeOnlineUser.mockResolvedValue(undefined)
+    dataMocks.buildQueueChangedData.mockResolvedValue({
+      roomId: "room123",
+      queue: [],
+      splitKey: null,
+    })
   })
 
   test("should be defined", () => {
@@ -294,7 +311,7 @@ describe("AdminHandlers", () => {
       expect(mockSocket.context.systemEvents.emit).toHaveBeenCalledWith(
         "room123",
         "QUEUE_CHANGED",
-        { roomId: "room123", queue: [] },
+        { roomId: "room123", queue: [], splitKey: null },
       )
     })
 

--- a/packages/server/handlers/adminHandlersAdapter.ts
+++ b/packages/server/handlers/adminHandlersAdapter.ts
@@ -7,7 +7,7 @@ import { HandlerConnections, AppContext } from "@repo/types"
 import { User } from "@repo/types/User"
 import { Room } from "@repo/types/Room"
 import { pubUserJoined } from "../operations/sockets/users"
-import { getRoomUsers, removeOnlineUser } from "../operations/data"
+import { getRoomUsers, removeOnlineUser, buildQueueChangedData, findRoom } from "../operations/data"
 
 /**
  * Socket.io adapter for the AdminService
@@ -461,10 +461,13 @@ export class AdminHandlers {
 
     // Emit via SystemEvents so broadcasters receive QUEUE_CHANGED
     if (socket.context.systemEvents) {
-      await socket.context.systemEvents.emit(socket.data.roomId, "QUEUE_CHANGED", {
+      const room = await findRoom({ context: socket.context, roomId: socket.data.roomId })
+      const payload = await buildQueueChangedData({
         roomId: socket.data.roomId,
-        queue: [],
+        context: socket.context,
+        appControlled: isAppControlledPlayback(room),
       })
+      await socket.context.systemEvents.emit(socket.data.roomId, "QUEUE_CHANGED", payload)
     }
   }
 

--- a/packages/server/handlers/djHandlersAdapter.test.ts
+++ b/packages/server/handlers/djHandlersAdapter.test.ts
@@ -116,6 +116,12 @@ describe("DJHandlers", () => {
       reorderQueue: vi.fn().mockResolvedValue({
         success: true,
       }),
+      setQueueSplit: vi.fn().mockResolvedValue({
+        success: true,
+      }),
+      removeQueueSplit: vi.fn().mockResolvedValue({
+        success: true,
+      }),
     }
 
     // Mock the AdapterService
@@ -500,6 +506,56 @@ describe("DJHandlers", () => {
       expect(mockSocket.emit).toHaveBeenCalledWith("event", {
         type: "REORDER_QUEUE_FAILURE",
         data: { message: "Not authorized" },
+      })
+    })
+  })
+
+  describe("setQueueSplit", () => {
+    test("calls djService.setQueueSplit with belowKey", async () => {
+      await djHandlers.setQueueSplit(
+        { socket: mockSocket, io: mockIo },
+        { belowKey: "spotify:track-b" },
+      )
+
+      expect(djService.setQueueSplit).toHaveBeenCalledWith("room1", "1", "spotify:track-b")
+    })
+
+    test("emits SET_QUEUE_SPLIT_SUCCESS when service succeeds", async () => {
+      djService.setQueueSplit.mockResolvedValueOnce({ success: true })
+
+      await djHandlers.setQueueSplit(
+        { socket: mockSocket, io: mockIo },
+        { belowKey: "spotify:track-b" },
+      )
+
+      expect(mockSocket.emit).toHaveBeenCalledWith("event", { type: "SET_QUEUE_SPLIT_SUCCESS" })
+    })
+
+    test("emits SET_QUEUE_SPLIT_FAILURE when payload is invalid", async () => {
+      await djHandlers.setQueueSplit({ socket: mockSocket, io: mockIo }, { belowKey: "" })
+
+      expect(mockSocket.emit).toHaveBeenCalledWith("event", {
+        type: "SET_QUEUE_SPLIT_FAILURE",
+        data: { message: "Invalid payload" },
+      })
+      expect(djService.setQueueSplit).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("removeQueueSplit", () => {
+    test("calls djService.removeQueueSplit", async () => {
+      await djHandlers.removeQueueSplit({ socket: mockSocket, io: mockIo })
+
+      expect(djService.removeQueueSplit).toHaveBeenCalledWith("room1", "1")
+    })
+
+    test("emits REMOVE_QUEUE_SPLIT_SUCCESS when service succeeds", async () => {
+      djService.removeQueueSplit.mockResolvedValueOnce({ success: true })
+
+      await djHandlers.removeQueueSplit({ socket: mockSocket, io: mockIo })
+
+      expect(mockSocket.emit).toHaveBeenCalledWith("event", {
+        type: "REMOVE_QUEUE_SPLIT_SUCCESS",
       })
     })
   })

--- a/packages/server/handlers/djHandlersAdapter.ts
+++ b/packages/server/handlers/djHandlersAdapter.ts
@@ -573,6 +573,58 @@ export class DJHandlers {
     }
   }
 
+  setQueueSplit = async (
+    { socket }: HandlerConnections,
+    { belowKey }: { belowKey: string },
+  ) => {
+    try {
+      const { roomId, userId } = socket.data
+      if (typeof belowKey !== "string" || belowKey.length === 0) {
+        socket.emit("event", {
+          type: "SET_QUEUE_SPLIT_FAILURE",
+          data: { message: "Invalid payload" },
+        })
+        return
+      }
+      const result = await this.djService.setQueueSplit(roomId, userId, belowKey)
+      if (!result.success) {
+        socket.emit("event", {
+          type: "SET_QUEUE_SPLIT_FAILURE",
+          data: { message: result.message },
+        })
+        return
+      }
+      socket.emit("event", { type: "SET_QUEUE_SPLIT_SUCCESS" })
+    } catch (error: any) {
+      console.error("Error setting queue split:", error)
+      socket.emit("event", {
+        type: "SET_QUEUE_SPLIT_FAILURE",
+        data: { message: error?.message || "Failed to set queue split" },
+      })
+    }
+  }
+
+  removeQueueSplit = async ({ socket }: HandlerConnections) => {
+    try {
+      const { roomId, userId } = socket.data
+      const result = await this.djService.removeQueueSplit(roomId, userId)
+      if (!result.success) {
+        socket.emit("event", {
+          type: "REMOVE_QUEUE_SPLIT_FAILURE",
+          data: { message: result.message },
+        })
+        return
+      }
+      socket.emit("event", { type: "REMOVE_QUEUE_SPLIT_SUCCESS" })
+    } catch (error: any) {
+      console.error("Error removing queue split:", error)
+      socket.emit("event", {
+        type: "REMOVE_QUEUE_SPLIT_FAILURE",
+        data: { message: error?.message || "Failed to remove queue split" },
+      })
+    }
+  }
+
   playQueuedTrack = async ({ socket }: HandlerConnections, { trackId }: { trackId: string }) => {
     try {
       const { roomId, userId } = socket.data

--- a/packages/server/lib/plugins/PluginAPI.test.ts
+++ b/packages/server/lib/plugins/PluginAPI.test.ts
@@ -31,7 +31,7 @@ vi.mock("../../operations/data", () => ({
   findRoom: vi.fn(),
   popNextFromQueue: vi.fn(),
   setDispatchedTrack: vi.fn(),
-  getQueueWithDispatched: vi.fn(),
+  buildQueueChangedData: vi.fn(),
   clearDispatchedTrack: vi.fn(),
 }))
 
@@ -44,7 +44,7 @@ import {
   findRoom,
   popNextFromQueue,
   setDispatchedTrack,
-  getQueueWithDispatched,
+  buildQueueChangedData,
   clearDispatchedTrack,
 } from "../../operations/data"
 
@@ -127,7 +127,11 @@ describe("PluginAPIImpl.skipTrack", () => {
     const nextItem = queueItemFactory.build({ track: nextTrack })
 
     vi.mocked(popNextFromQueue).mockResolvedValue(nextItem)
-    vi.mocked(getQueueWithDispatched).mockResolvedValue([nextItem])
+    vi.mocked(buildQueueChangedData).mockResolvedValue({
+      roomId,
+      queue: [nextItem],
+      splitKey: null,
+    })
 
     await api.skipTrack(roomId, trackId)
 
@@ -142,6 +146,7 @@ describe("PluginAPIImpl.skipTrack", () => {
     expect(mockContext.systemEvents?.emit).toHaveBeenCalledWith(roomId, "QUEUE_CHANGED", {
       roomId,
       queue: [nextItem],
+      splitKey: null,
     })
   })
 

--- a/packages/server/lib/plugins/PluginAPI.ts
+++ b/packages/server/lib/plugins/PluginAPI.ts
@@ -117,7 +117,7 @@ export class PluginAPIImpl implements PluginAPI {
       findRoom,
       popNextFromQueue,
       setDispatchedTrack,
-      getQueueWithDispatched,
+      buildQueueChangedData,
       clearDispatchedTrack,
     } = await import("../../operations/data")
     const { isAppControlledPlayback } = await import("../roomTypeHelpers")
@@ -167,11 +167,12 @@ export class PluginAPIImpl implements PluginAPI {
     }
 
     if (this.context.systemEvents) {
-      const updatedQueue = await getQueueWithDispatched({ context: this.context, roomId })
-      await this.context.systemEvents.emit(roomId, "QUEUE_CHANGED", {
+      const payload = await buildQueueChangedData({
         roomId,
-        queue: updatedQueue,
+        context: this.context,
+        appControlled: true,
       })
+      await this.context.systemEvents.emit(roomId, "QUEUE_CHANGED", payload)
     }
   }
 

--- a/packages/server/operations/data/djs.queueSplit.test.ts
+++ b/packages/server/operations/data/djs.queueSplit.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import type { AppContext } from "@repo/types"
+import { canonicalQueueTrackKey } from "@repo/types/Queue"
+import { queueItemFactory } from "@repo/factories/queueItem"
+import { MemoryRedisClient } from "../../test-utils/MemoryRedisClient"
+import {
+  addToQueue,
+  buildQueueChangedData,
+  clearQueueSplit,
+  getNormalizedQueueSplit,
+  getQueueSplit,
+  queueSplitStorageKey,
+  removeFromQueue,
+  reanchorQueueSplitOnRemoval,
+  setQueueSplit,
+} from "./djs"
+
+const ROOM_ID = "room-split-test"
+
+function makeContext(client: MemoryRedisClient): AppContext {
+  return {
+    redis: {
+      pubClient: client as unknown as AppContext["redis"]["pubClient"],
+      subClient: client as unknown as AppContext["redis"]["subClient"],
+    },
+  } as AppContext
+}
+
+function itemWithId(id: string, addedAt: number) {
+  const track = queueItemFactory.build().track
+  track.id = id
+  return queueItemFactory.build({
+    track,
+    mediaSource: { type: "spotify", trackId: id },
+    metadataSource: { type: "spotify", trackId: id },
+    addedAt,
+  })
+}
+
+describe("queue split data layer", () => {
+  let client: MemoryRedisClient
+  let context: AppContext
+
+  beforeEach(() => {
+    client = new MemoryRedisClient()
+    context = makeContext(client)
+  })
+
+  it("getNormalizedQueueSplit returns anchor when at index >= 1", async () => {
+    const a = itemWithId("track-a", 1)
+    const b = itemWithId("track-b", 2)
+    const c = itemWithId("track-c", 3)
+    await addToQueue({ roomId: ROOM_ID, item: a, context })
+    await addToQueue({ roomId: ROOM_ID, item: b, context })
+    await addToQueue({ roomId: ROOM_ID, item: c, context })
+
+    const belowKey = canonicalQueueTrackKey(b)
+    await setQueueSplit({ roomId: ROOM_ID, context, belowKey })
+
+    await expect(getNormalizedQueueSplit({ roomId: ROOM_ID, context })).resolves.toBe(belowKey)
+  })
+
+  it("getNormalizedQueueSplit clears when anchor is at index 0", async () => {
+    const a = itemWithId("track-a", 1)
+    const b = itemWithId("track-b", 2)
+    await addToQueue({ roomId: ROOM_ID, item: a, context })
+    await addToQueue({ roomId: ROOM_ID, item: b, context })
+
+    await setQueueSplit({ roomId: ROOM_ID, context, belowKey: canonicalQueueTrackKey(a) })
+
+    await expect(getNormalizedQueueSplit({ roomId: ROOM_ID, context })).resolves.toBeNull()
+    await expect(getQueueSplit({ roomId: ROOM_ID, context })).resolves.toBeNull()
+  })
+
+  it("getNormalizedQueueSplit clears when anchor is missing from queue", async () => {
+    await client.set(queueSplitStorageKey(ROOM_ID), "spotify:ghost")
+
+    await expect(getNormalizedQueueSplit({ roomId: ROOM_ID, context })).resolves.toBeNull()
+    await expect(getQueueSplit({ roomId: ROOM_ID, context })).resolves.toBeNull()
+  })
+
+  it("reanchorQueueSplitOnRemoval points split at the next track below", async () => {
+    const a = itemWithId("track-a", 1)
+    const b = itemWithId("track-b", 2)
+    const c = itemWithId("track-c", 3)
+    await addToQueue({ roomId: ROOM_ID, item: a, context })
+    await addToQueue({ roomId: ROOM_ID, item: b, context })
+    await addToQueue({ roomId: ROOM_ID, item: c, context })
+
+    const anchorKey = canonicalQueueTrackKey(b)
+    await setQueueSplit({ roomId: ROOM_ID, context, belowKey: anchorKey })
+
+    await removeFromQueue({ roomId: ROOM_ID, trackId: anchorKey, context })
+
+    await expect(getQueueSplit({ roomId: ROOM_ID, context })).resolves.toBe(
+      canonicalQueueTrackKey(c),
+    )
+  })
+
+  it("reanchorQueueSplitOnRemoval clears split when anchor was the last track", async () => {
+    const a = itemWithId("track-a", 1)
+    const b = itemWithId("track-b", 2)
+    await addToQueue({ roomId: ROOM_ID, item: a, context })
+    await addToQueue({ roomId: ROOM_ID, item: b, context })
+
+    const anchorKey = canonicalQueueTrackKey(b)
+    await setQueueSplit({ roomId: ROOM_ID, context, belowKey: anchorKey })
+
+    await removeFromQueue({ roomId: ROOM_ID, trackId: anchorKey, context })
+
+    await expect(getQueueSplit({ roomId: ROOM_ID, context })).resolves.toBeNull()
+  })
+
+  it("reanchorQueueSplitOnRemoval is a no-op when removed track is not the anchor", async () => {
+    const a = itemWithId("track-a", 1)
+    const b = itemWithId("track-b", 2)
+    await addToQueue({ roomId: ROOM_ID, item: a, context })
+    await addToQueue({ roomId: ROOM_ID, item: b, context })
+
+    const anchorKey = canonicalQueueTrackKey(b)
+    await setQueueSplit({ roomId: ROOM_ID, context, belowKey: anchorKey })
+
+    await reanchorQueueSplitOnRemoval({
+      roomId: ROOM_ID,
+      context,
+      removedKey: canonicalQueueTrackKey(a),
+    })
+
+    await expect(getQueueSplit({ roomId: ROOM_ID, context })).resolves.toBe(anchorKey)
+  })
+
+  it("clearQueueSplit removes stored anchor", async () => {
+    await setQueueSplit({ roomId: ROOM_ID, context, belowKey: "spotify:x" })
+    await clearQueueSplit({ roomId: ROOM_ID, context })
+    await expect(getQueueSplit({ roomId: ROOM_ID, context })).resolves.toBeNull()
+  })
+
+  it("buildQueueChangedData includes normalized splitKey for app-controlled rooms", async () => {
+    const a = itemWithId("track-a", 1)
+    const b = itemWithId("track-b", 2)
+    await addToQueue({ roomId: ROOM_ID, item: a, context })
+    await addToQueue({ roomId: ROOM_ID, item: b, context })
+    await setQueueSplit({ roomId: ROOM_ID, context, belowKey: canonicalQueueTrackKey(b) })
+
+    const payload = await buildQueueChangedData({
+      roomId: ROOM_ID,
+      context,
+      appControlled: true,
+    })
+
+    expect(payload.splitKey).toBe(canonicalQueueTrackKey(b))
+    expect(payload.queue.map((item) => canonicalQueueTrackKey(item))).toEqual([
+      canonicalQueueTrackKey(a),
+      canonicalQueueTrackKey(b),
+    ])
+  })
+
+  it("buildQueueChangedData omits split for spotify-controlled rooms", async () => {
+    await setQueueSplit({ roomId: ROOM_ID, context, belowKey: "spotify:x" })
+
+    const payload = await buildQueueChangedData({
+      roomId: ROOM_ID,
+      context,
+      appControlled: false,
+    })
+
+    expect(payload.splitKey).toBeNull()
+    expect(payload.queue).toEqual([])
+  })
+})

--- a/packages/server/operations/data/djs.ts
+++ b/packages/server/operations/data/djs.ts
@@ -19,6 +19,11 @@ export function dispatchedTrackKey(roomId: string) {
   return `room:${roomId}:dispatched_track`
 }
 
+/** Canonical key of the first track below the queue split divider (reserved lower section). */
+export function queueSplitStorageKey(roomId: string) {
+  return `room:${roomId}:queue_split`
+}
+
 const DISPATCHED_TTL_SEC = 60
 
 /** Atomic pop lowest-score member from ZSET (same semantics as ZPOPMIN). */
@@ -161,6 +166,118 @@ export async function clearDispatchedTrack({
   }
 }
 
+export async function getQueueSplit({
+  roomId,
+  context,
+}: {
+  roomId: string
+  context: AppContext
+}): Promise<string | null> {
+  try {
+    const raw = await context.redis.pubClient.get(queueSplitStorageKey(roomId))
+    if (!raw) return null
+    return raw
+  } catch (e) {
+    console.error("[getQueueSplit]", roomId, e)
+    return null
+  }
+}
+
+export async function setQueueSplit({
+  roomId,
+  context,
+  belowKey,
+}: {
+  roomId: string
+  context: AppContext
+  belowKey: string
+}) {
+  try {
+    await context.redis.pubClient.set(queueSplitStorageKey(roomId), belowKey)
+  } catch (e) {
+    console.error("[setQueueSplit]", roomId, belowKey, e)
+  }
+}
+
+export async function clearQueueSplit({
+  roomId,
+  context,
+}: {
+  roomId: string
+  context: AppContext
+}) {
+  try {
+    await context.redis.pubClient.unlink(queueSplitStorageKey(roomId))
+  } catch (e) {
+    console.error("[clearQueueSplit]", roomId, e)
+  }
+}
+
+/**
+ * Return the split anchor when it still points at a track with at least one track above it.
+ * Clears stale split state when the anchor is missing or has reached queue head (index 0).
+ */
+export async function getNormalizedQueueSplit({
+  roomId,
+  context,
+}: {
+  roomId: string
+  context: AppContext
+}): Promise<string | null> {
+  const belowKey = await getQueueSplit({ roomId, context })
+  if (!belowKey) return null
+
+  const queue = await getQueue({ roomId, context })
+  const index = queue.findIndex((item) => canonicalQueueTrackKey(item) === belowKey)
+
+  if (index < 1) {
+    await clearQueueSplit({ roomId, context })
+    return null
+  }
+
+  return belowKey
+}
+
+/**
+ * When the split anchor track is removed, re-point the split to the next track below
+ * (or clear if the anchor was the last track). Must run before ZREM on queue_order.
+ */
+export async function reanchorQueueSplitOnRemoval({
+  roomId,
+  context,
+  removedKey,
+}: {
+  roomId: string
+  context: AppContext
+  removedKey: string
+}) {
+  try {
+    await ensureQueueMigrated({ roomId, context })
+    const splitKey = await getQueueSplit({ roomId, context })
+    if (!splitKey || splitKey !== removedKey) {
+      return
+    }
+
+    const client = context.redis.pubClient
+    const orderKey = queueOrderKey(roomId)
+    const rank = await client.zRank(orderKey, removedKey)
+    if (rank == null) {
+      await clearQueueSplit({ roomId, context })
+      return
+    }
+
+    const successors = await client.zRange(orderKey, rank + 1, rank + 1)
+    const successor = successors[0]
+    if (successor) {
+      await setQueueSplit({ roomId, context, belowKey: successor })
+    } else {
+      await clearQueueSplit({ roomId, context })
+    }
+  } catch (e) {
+    console.error("[reanchorQueueSplitOnRemoval]", roomId, removedKey, e)
+  }
+}
+
 export async function addDj({
   roomId,
   userId,
@@ -261,6 +378,7 @@ export async function removeFromQueue({
   context: AppContext
 }) {
   await ensureQueueMigrated({ roomId, context })
+  await reanchorQueueSplitOnRemoval({ roomId, context, removedKey: trackId })
   await context.redis.pubClient.zRem(queueOrderKey(roomId), trackId)
   await context.redis.pubClient.unlink(`room:${roomId}:queued_track:${trackId}`)
   return null
@@ -315,6 +433,25 @@ export async function getQueueWithDispatched({
     return [{ ...dispatched, locked: true }, ...queue]
   }
   return queue
+}
+
+/** Wire payload for INIT / QUEUE_CHANGED — queue snapshot plus normalized split anchor. */
+export async function buildQueueChangedData({
+  roomId,
+  context,
+  appControlled,
+}: {
+  roomId: string
+  context: AppContext
+  appControlled: boolean
+}): Promise<{ roomId: string; queue: QueueItem[]; splitKey: string | null }> {
+  const splitKey = appControlled
+    ? await getNormalizedQueueSplit({ roomId, context })
+    : null
+  const queue = appControlled
+    ? await getQueueWithDispatched({ roomId, context })
+    : await getQueue({ roomId, context })
+  return { roomId, queue, splitKey }
 }
 
 /**
@@ -438,6 +575,7 @@ export async function clearQueue({ roomId, context }: { roomId: string; context:
     )
     await context.redis.pubClient.unlink(orderKey)
     await context.redis.pubClient.unlink(legacyQueueSetKey(roomId))
+    await clearQueueSplit({ roomId, context })
     return []
   } catch (e) {
     console.log("ERROR FROM data/djs/clearQueue", roomId)

--- a/packages/server/operations/injectSegmentTracksToQueue.test.ts
+++ b/packages/server/operations/injectSegmentTracksToQueue.test.ts
@@ -9,7 +9,7 @@ const m = vi.hoisted(() => ({
   findShowSegmentTracks: vi.fn(),
   getQueue: vi.fn(),
   setQueue: vi.fn(),
-  getQueueWithDispatched: vi.fn(),
+  buildQueueChangedData: vi.fn(),
   queueSongAs: vi.fn(),
 }))
 
@@ -25,7 +25,7 @@ vi.mock("./data", () => ({
 }))
 
 vi.mock("./data/djs", () => ({
-  getQueueWithDispatched: m.getQueueWithDispatched,
+  buildQueueChangedData: m.buildQueueChangedData,
 }))
 
 vi.mock("../services/DJService", () => ({
@@ -74,10 +74,11 @@ describe("injectSegmentTracksToQueue", () => {
       { track: { id: "t1" } },
       { track: { id: "t2" } },
     ])
-    m.getQueueWithDispatched.mockResolvedValue([
-      { track: { id: "t1" } },
-      { track: { id: "t2" } },
-    ])
+    m.buildQueueChangedData.mockResolvedValue({
+      roomId: "r1",
+      queue: [{ track: { id: "t1" } }, { track: { id: "t2" } }],
+      splitKey: null,
+    })
   })
 
   it("rejects top placement for spotify-controlled rooms", async () => {

--- a/packages/server/operations/injectSegmentTracksToQueue.ts
+++ b/packages/server/operations/injectSegmentTracksToQueue.ts
@@ -3,7 +3,7 @@ import type { Room } from "@repo/types/Room"
 import { findShowSegmentTracks } from "../services/SchedulingService"
 import { DJService } from "../services/DJService"
 import { findRoom, getQueue, isRoomAdmin, setQueue } from "./data"
-import { getQueueWithDispatched } from "./data/djs"
+import { buildQueueChangedData } from "./data/djs"
 import { isAppControlledPlayback } from "../lib/roomTypeHelpers"
 
 export type SegmentTrackInjectionPlacement = "top" | "bottom"
@@ -16,10 +16,12 @@ export type InjectSegmentTracksResult =
 
 async function emitQueueChanged(context: AppContext, roomId: string, room: Room): Promise<void> {
   if (!context.systemEvents) return
-  const queue = isAppControlledPlayback(room)
-    ? await getQueueWithDispatched({ context, roomId })
-    : await getQueue({ context, roomId })
-  await context.systemEvents.emit(roomId, "QUEUE_CHANGED", { roomId, queue })
+  const payload = await buildQueueChangedData({
+    roomId,
+    context,
+    appControlled: isAppControlledPlayback(room),
+  })
+  await context.systemEvents.emit(roomId, "QUEUE_CHANGED", payload)
 }
 
 export async function injectSegmentTracksToQueue(params: {

--- a/packages/server/operations/room/handleRoomNowPlayingData.ts
+++ b/packages/server/operations/room/handleRoomNowPlayingData.ts
@@ -14,6 +14,7 @@ import {
 import type { MetadataSourceType } from "@repo/types/TrackSource"
 import {
   addTrackToRoomPlaylist,
+  buildQueueChangedData,
   clearDispatchedTrack,
   clearRoomCurrent,
   findRoom,
@@ -256,24 +257,24 @@ export default async function handleRoomNowPlayingData({
 
     // Emit QUEUE_CHANGED event after removing track
     if (context.systemEvents) {
-      const updatedQueue = isAppControlledPlayback(room)
-        ? await getQueueWithDispatched({ context, roomId })
-        : await getQueue({ context, roomId })
-      await context.systemEvents.emit(roomId, "QUEUE_CHANGED", {
+      const payload = await buildQueueChangedData({
         roomId,
-        queue: updatedQueue,
+        context,
+        appControlled: isAppControlledPlayback(room),
       })
+      await context.systemEvents.emit(roomId, "QUEUE_CHANGED", payload)
     }
   }
 
   if (queueMatchSource === "dispatched") {
     await clearDispatchedTrack({ context, roomId })
     if (context.systemEvents && isAppControlledPlayback(room)) {
-      const updatedQueue = await getQueueWithDispatched({ context, roomId })
-      await context.systemEvents.emit(roomId, "QUEUE_CHANGED", {
+      const payload = await buildQueueChangedData({
         roomId,
-        queue: updatedQueue,
+        context,
+        appControlled: true,
       })
+      await context.systemEvents.emit(roomId, "QUEUE_CHANGED", payload)
     }
   }
 }

--- a/packages/server/services/AuthService.ts
+++ b/packages/server/services/AuthService.ts
@@ -30,6 +30,7 @@ import {
   setRoomPollingPaused,
   getQueue,
   getQueueWithDispatched,
+  getNormalizedQueueSplit,
   isRoomAdmin,
   addUserToRoomHistory,
 } from "../operations/data"
@@ -231,6 +232,9 @@ export class AuthService {
     const queue = isAppControlledPlayback(room)
       ? await getQueueWithDispatched({ context: this.context, roomId })
       : await getQueue({ context: this.context, roomId })
+    const splitKey = isAppControlledPlayback(room)
+      ? await getNormalizedQueueSplit({ context: this.context, roomId })
+      : null
     const streamHealthStatus =
       room.type === "live" ? await getStreamHealthStatus(this.context, roomId) : null
     const webrtcStreamHealthStatus = isHybridRadioRoom(room)
@@ -288,6 +292,7 @@ export class AuthService {
         passwordRequired: !isNullish(room?.password),
         playlist,
         queue,
+        splitKey,
         reactions: allReactions,
         pluginConfigs,
         user: {

--- a/packages/server/services/DJService.test.ts
+++ b/packages/server/services/DJService.test.ts
@@ -8,11 +8,14 @@ import { canonicalQueueTrackKey } from "@repo/types/Queue"
 vi.mock("../operations/data", () => ({
   addDj: vi.fn(),
   addToQueue: vi.fn(),
+  buildQueueChangedData: vi.fn(),
   clearDispatchedTrack: vi.fn(),
+  clearQueueSplit: vi.fn(),
   findRoom: vi.fn(),
   getDispatchedTrack: vi.fn(),
   getDjs: vi.fn(),
   getQueue: vi.fn(),
+  getNormalizedQueueSplit: vi.fn(),
   getQueueWithDispatched: vi.fn(),
   getUser: vi.fn(),
   isDj: vi.fn(),
@@ -20,6 +23,7 @@ vi.mock("../operations/data", () => ({
   removeDj: vi.fn(),
   removeFromQueue: vi.fn(),
   setQueue: vi.fn(),
+  setQueueSplit: vi.fn(),
   setDispatchedTrack: vi.fn(),
   updateUserAttributes: vi.fn(),
 }))
@@ -39,11 +43,14 @@ import systemMessage from "../lib/systemMessage"
 import {
   addDj,
   addToQueue,
+  buildQueueChangedData,
   clearDispatchedTrack,
+  clearQueueSplit,
   findRoom,
   getDispatchedTrack,
   getDjs,
   getQueue,
+  getNormalizedQueueSplit,
   getQueueWithDispatched,
   getUser,
   isDj,
@@ -51,6 +58,7 @@ import {
   removeDj,
   removeFromQueue,
   setQueue,
+  setQueueSplit,
   setDispatchedTrack,
   updateUserAttributes,
 } from "../operations/data"
@@ -85,10 +93,18 @@ describe("DJService", () => {
     vi.mocked(getQueueWithDispatched).mockImplementation(async (params) => {
       return vi.mocked(getQueue)(params) as Promise<QueueItem[]>
     })
+    vi.mocked(buildQueueChangedData).mockImplementation(async ({ roomId, appControlled }) => ({
+      roomId,
+      queue: appControlled
+        ? await vi.mocked(getQueueWithDispatched)({ context: mockContext, roomId })
+        : await vi.mocked(getQueue)({ context: mockContext, roomId }),
+      splitKey: null,
+    }))
 
     // Setup default mocks
     vi.mocked(getUser).mockResolvedValue(mockUser)
     vi.mocked(getQueue).mockResolvedValue([])
+    vi.mocked(getNormalizedQueueSplit).mockResolvedValue(null)
     vi.mocked(updateUserAttributes).mockResolvedValue({
       user: mockUser,
       users: [mockUser],
@@ -774,7 +790,112 @@ describe("DJService", () => {
       expect(mockContext.systemEvents?.emit).toHaveBeenCalledWith("room123", "QUEUE_CHANGED", {
         roomId: "room123",
         queue: [itemB, itemA],
+        splitKey: null,
       })
+    })
+  })
+
+  describe("queue split", () => {
+    const appControlledRoom = roomFactory.build({
+      id: "room123",
+      creator: "creator1",
+      playbackMode: "app-controlled",
+    })
+
+    const itemA = queueItemFactory.build({
+      mediaSource: { type: "spotify", trackId: "track-a" },
+      track: metadataSourceTrackFactory.build({ id: "track-a", title: "A" }),
+    })
+    const itemB = queueItemFactory.build({
+      mediaSource: { type: "spotify", trackId: "track-b" },
+      track: metadataSourceTrackFactory.build({ id: "track-b", title: "B" }),
+    })
+
+    test("setQueueSplit rejects when not app-controlled", async () => {
+      vi.mocked(findRoom).mockResolvedValue(
+        roomFactory.build({ playbackMode: "spotify-controlled" }),
+      )
+
+      const result = await djService.setQueueSplit(
+        "room123",
+        "user123",
+        canonicalQueueTrackKey(itemB),
+      )
+
+      expect(result).toEqual({
+        success: false,
+        message: "Queue split is only available in app-controlled playback mode",
+      })
+      expect(setQueueSplit).not.toHaveBeenCalled()
+    })
+
+    test("setQueueSplit rejects when user is not authorized", async () => {
+      vi.mocked(findRoom).mockResolvedValue(appControlledRoom)
+      vi.mocked(getQueue).mockResolvedValue([itemA, itemB])
+      vi.mocked(isRoomAdmin).mockResolvedValue(false)
+
+      const result = await djService.setQueueSplit(
+        "room123",
+        "user123",
+        canonicalQueueTrackKey(itemB),
+      )
+
+      expect(result).toEqual({
+        success: false,
+        message: "Not authorized to set the queue split",
+      })
+    })
+
+    test("setQueueSplit persists anchor and emits QUEUE_CHANGED when valid", async () => {
+      vi.mocked(findRoom).mockResolvedValue(appControlledRoom)
+      vi.mocked(getQueue).mockResolvedValue([itemA, itemB])
+      vi.mocked(isRoomAdmin).mockResolvedValue(true)
+
+      const belowKey = canonicalQueueTrackKey(itemB)
+      const result = await djService.setQueueSplit("room123", "user123", belowKey)
+
+      expect(result).toEqual({ success: true })
+      expect(setQueueSplit).toHaveBeenCalledWith({
+        context: mockContext,
+        roomId: "room123",
+        belowKey,
+      })
+      expect(mockContext.systemEvents?.emit).toHaveBeenCalledWith(
+        "room123",
+        "QUEUE_CHANGED",
+        expect.objectContaining({ roomId: "room123", splitKey: null }),
+      )
+    })
+
+    test("setQueueSplit at index 0 clears split instead of persisting", async () => {
+      vi.mocked(findRoom).mockResolvedValue(appControlledRoom)
+      vi.mocked(getQueue).mockResolvedValue([itemA, itemB])
+      vi.mocked(isRoomAdmin).mockResolvedValue(true)
+
+      const result = await djService.setQueueSplit(
+        "room123",
+        "user123",
+        canonicalQueueTrackKey(itemA),
+      )
+
+      expect(result).toEqual({ success: true })
+      expect(clearQueueSplit).toHaveBeenCalledWith({ context: mockContext, roomId: "room123" })
+      expect(setQueueSplit).not.toHaveBeenCalled()
+    })
+
+    test("removeQueueSplit clears anchor and emits QUEUE_CHANGED", async () => {
+      vi.mocked(findRoom).mockResolvedValue(appControlledRoom)
+      vi.mocked(isRoomAdmin).mockResolvedValue(true)
+
+      const result = await djService.removeQueueSplit("room123", "user123")
+
+      expect(result).toEqual({ success: true })
+      expect(clearQueueSplit).toHaveBeenCalledWith({ context: mockContext, roomId: "room123" })
+      expect(mockContext.systemEvents?.emit).toHaveBeenCalledWith(
+        "room123",
+        "QUEUE_CHANGED",
+        expect.objectContaining({ roomId: "room123" }),
+      )
     })
   })
 
@@ -906,6 +1027,62 @@ describe("DJService", () => {
 
         expect(result).toEqual({ success: false, message: "rate limited" })
         expect(addToQueue).not.toHaveBeenCalled()
+      })
+
+      test("app-controlled with split: inserts new track immediately before split anchor", async () => {
+        vi.mocked(addToQueue).mockResolvedValue(undefined)
+        vi.mocked(findRoom).mockResolvedValue(appControlledRoom)
+
+        const mockTrack = metadataSourceTrackFactory.build({
+          id: "track-new",
+          title: "New Track",
+          urls: [{ type: "resource", url: "spotify:track:new", id: "url-new" }],
+        })
+        const itemA = queueItemFactory.build({
+          mediaSource: { type: "spotify", trackId: "track-a" },
+          track: metadataSourceTrackFactory.build({ id: "track-a", title: "A" }),
+        })
+        const itemB = queueItemFactory.build({
+          mediaSource: { type: "spotify", trackId: "track-b" },
+          track: metadataSourceTrackFactory.build({ id: "track-b", title: "B" }),
+        })
+        const queuedItem = queueItemFactory.build({
+          track: mockTrack,
+          mediaSource: { type: "spotify", trackId: "track-new" },
+          metadataSource: { type: "spotify", trackId: "track-new" },
+        })
+
+        vi.mocked(getQueue)
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([itemA, itemB, queuedItem])
+        vi.mocked(getNormalizedQueueSplit).mockResolvedValue(
+          canonicalQueueTrackKey(itemB),
+        )
+        vi.mocked(addToQueue).mockImplementation(async ({ item }) => {
+          Object.assign(queuedItem, item)
+        })
+
+        // @ts-ignore — testing private property
+        djService["adapterService"].getUserMetadataSource = vi.fn().mockResolvedValue({
+          api: { findById: vi.fn().mockResolvedValue(mockTrack) },
+        })
+        // @ts-ignore
+        djService["adapterService"].getRoomPlaybackController = vi.fn().mockResolvedValue({
+          api: { addToQueue: vi.fn() },
+        })
+
+        const result = await djService.queueSongAs(
+          "room123",
+          { type: "user", userId: "user123", username: "Homer" },
+          "track-new",
+        )
+
+        expect(result.success).toBe(true)
+        expect(setQueue).toHaveBeenCalledWith({
+          context: mockContext,
+          roomId: "room123",
+          items: [itemA, expect.objectContaining({ track: mockTrack }), itemB],
+        })
       })
     })
 

--- a/packages/server/services/DJService.ts
+++ b/packages/server/services/DJService.ts
@@ -6,9 +6,12 @@ import { MetadataSource, MetadataSourceTrack } from "@repo/types"
 import {
   addDj,
   addToQueue,
+  buildQueueChangedData,
+  clearQueueSplit,
   findRoom,
   getDjs,
   getQueue,
+  getNormalizedQueueSplit,
   getQueueWithDispatched,
   getUser,
   isDj,
@@ -18,6 +21,7 @@ import {
   clearDispatchedTrack,
   setDispatchedTrack,
   setQueue,
+  setQueueSplit as persistQueueSplit,
   updateUserAttributes,
 } from "../operations/data"
 import systemMessage from "../lib/systemMessage"
@@ -243,6 +247,31 @@ export class DJService {
 
     await addToQueue({ context: this.context, roomId, item: queuedItem })
 
+    if (isAppControlledPlayback(room)) {
+      const belowKey = await getNormalizedQueueSplit({ context: this.context, roomId })
+      if (belowKey) {
+        const updatedQueue = await getQueue({ context: this.context, roomId })
+        const addedKey = canonicalQueueTrackKey(queuedItem)
+        const withoutAdded = updatedQueue.filter(
+          (item) => canonicalQueueTrackKey(item) !== addedKey,
+        )
+        const belowIndex = withoutAdded.findIndex(
+          (item) => canonicalQueueTrackKey(item) === belowKey,
+        )
+        if (belowIndex >= 0) {
+          await setQueue({
+            roomId,
+            items: [
+              ...withoutAdded.slice(0, belowIndex),
+              queuedItem,
+              ...withoutAdded.slice(belowIndex),
+            ],
+            context: this.context,
+          })
+        }
+      }
+    }
+
     // Spotify-native queue (default). App-controlled: Redis-only queue; advance job / explicit Play start Spotify.
     if (!isAppControlledPlayback(room)) {
       try {
@@ -260,13 +289,12 @@ export class DJService {
     }
 
     if (this.context.systemEvents && !suppressQueueChanged) {
-      const updatedQueue = isAppControlledPlayback(room)
-        ? await getQueueWithDispatched({ context: this.context, roomId })
-        : await getQueue({ context: this.context, roomId })
-      await this.context.systemEvents.emit(roomId, "QUEUE_CHANGED", {
+      const payload = await buildQueueChangedData({
         roomId,
-        queue: updatedQueue,
+        context: this.context,
+        appControlled: isAppControlledPlayback(room),
       })
+      await this.context.systemEvents.emit(roomId, "QUEUE_CHANGED", payload)
     }
 
     return {
@@ -399,11 +427,89 @@ export class DJService {
     await setQueue({ roomId, items, context: this.context })
 
     if (this.context.systemEvents) {
-      const updatedQueue = await getQueueWithDispatched({ context: this.context, roomId })
-      await this.context.systemEvents.emit(roomId, "QUEUE_CHANGED", {
+      const payload = await buildQueueChangedData({
         roomId,
-        queue: updatedQueue,
+        context: this.context,
+        appControlled: true,
       })
+      await this.context.systemEvents.emit(roomId, "QUEUE_CHANGED", payload)
+    }
+
+    return { success: true as const }
+  }
+
+  /**
+   * Set the queue split anchor (app-controlled, room admins only). Emits QUEUE_CHANGED via systemEvents.
+   */
+  async setQueueSplit(roomId: string, userId: string, belowKey: string) {
+    const room = await findRoom({ context: this.context, roomId })
+    if (!room) {
+      return { success: false as const, message: "Room not found" }
+    }
+    if (!isAppControlledPlayback(room)) {
+      return {
+        success: false as const,
+        message: "Queue split is only available in app-controlled playback mode",
+      }
+    }
+
+    const allowed = await this.userCanReorderQueueInRoom(roomId, userId)
+    if (!allowed) {
+      return { success: false as const, message: "Not authorized to set the queue split" }
+    }
+
+    const queue = await getQueue({ context: this.context, roomId })
+    const index = queue.findIndex((item) => canonicalQueueTrackKey(item) === belowKey)
+    if (index < 0) {
+      return { success: false as const, message: "Invalid queue split position" }
+    }
+    if (index === 0) {
+      await clearQueueSplit({ context: this.context, roomId })
+    } else {
+      await persistQueueSplit({ context: this.context, roomId, belowKey })
+    }
+
+    if (this.context.systemEvents) {
+      const payload = await buildQueueChangedData({
+        roomId,
+        context: this.context,
+        appControlled: true,
+      })
+      await this.context.systemEvents.emit(roomId, "QUEUE_CHANGED", payload)
+    }
+
+    return { success: true as const }
+  }
+
+  /**
+   * Remove the queue split (app-controlled, room admins only). Emits QUEUE_CHANGED via systemEvents.
+   */
+  async removeQueueSplit(roomId: string, userId: string) {
+    const room = await findRoom({ context: this.context, roomId })
+    if (!room) {
+      return { success: false as const, message: "Room not found" }
+    }
+    if (!isAppControlledPlayback(room)) {
+      return {
+        success: false as const,
+        message: "Queue split is only available in app-controlled playback mode",
+      }
+    }
+
+    const allowed = await this.userCanReorderQueueInRoom(roomId, userId)
+    if (!allowed) {
+      return { success: false as const, message: "Not authorized to remove the queue split" }
+    }
+
+    await clearQueueSplit({ context: this.context, roomId })
+
+    if (this.context.systemEvents) {
+      const payload = await buildQueueChangedData({
+        roomId,
+        context: this.context,
+        appControlled: true,
+      })
+      await this.context.systemEvents.emit(roomId, "QUEUE_CHANGED", payload)
     }
 
     return { success: true as const }
@@ -470,11 +576,12 @@ export class DJService {
     await removeFromQueue({ context: this.context, roomId, trackId: trackKey })
 
     if (this.context.systemEvents) {
-      const updatedQueue = await getQueueWithDispatched({ context: this.context, roomId })
-      await this.context.systemEvents.emit(roomId, "QUEUE_CHANGED", {
+      const payload = await buildQueueChangedData({
         roomId,
-        queue: updatedQueue,
+        context: this.context,
+        appControlled: true,
       })
+      await this.context.systemEvents.emit(roomId, "QUEUE_CHANGED", payload)
     }
 
     const title = queueItem.track.title || queueItem.title || "Track"
@@ -552,11 +659,12 @@ export class DJService {
     }
 
     if (this.context.systemEvents) {
-      const updatedQueue = await getQueueWithDispatched({ context: this.context, roomId })
-      await this.context.systemEvents.emit(roomId, "QUEUE_CHANGED", {
+      const payload = await buildQueueChangedData({
         roomId,
-        queue: updatedQueue,
+        context: this.context,
+        appControlled: true,
       })
+      await this.context.systemEvents.emit(roomId, "QUEUE_CHANGED", payload)
     }
 
     return {
@@ -703,8 +811,12 @@ export class DJService {
    */
   private async emitQueueChanged(roomId: string): Promise<void> {
     if (!this.context.systemEvents) return
-    const queue = await getQueueWithDispatched({ context: this.context, roomId })
-    await this.context.systemEvents.emit(roomId, "QUEUE_CHANGED", { roomId, queue })
+    const payload = await buildQueueChangedData({
+      roomId,
+      context: this.context,
+      appControlled: true,
+    })
+    await this.context.systemEvents.emit(roomId, "QUEUE_CHANGED", payload)
   }
 
   /**

--- a/packages/server/test-utils/MemoryRedisClient.ts
+++ b/packages/server/test-utils/MemoryRedisClient.ts
@@ -91,7 +91,28 @@ export class MemoryRedisClient {
     const sorted = [...zset.entries()].sort((a, b) =>
       opts?.REV ? b[1] - a[1] : a[1] - b[1],
     )
-    const end = stop < 0 ? sorted.length + stop : stop + 1
-    return sorted.slice(start, end).map(([member]) => member)
+    const len = sorted.length
+    if (len === 0) return []
+
+    // Redis ZRANGE: start/stop are inclusive; negative stop counts from the end.
+    let from = start < 0 ? len + start : start
+    let to = stop < 0 ? len + stop : stop
+    if (from >= len || to < 0) return []
+    from = Math.max(0, from)
+    to = Math.min(to, len - 1)
+    if (from > to) return []
+
+    return sorted.slice(from, to + 1).map(([member]) => member)
+  }
+
+  async zRank(key: string, member: string): Promise<number | null> {
+    const zset = this.zsets.get(key)
+    if (!zset || !zset.has(member)) return null
+    const sorted = [...zset.entries()].sort((a, b) => a[1] - b[1])
+    return sorted.findIndex(([m]) => m === member)
+  }
+
+  async zCard(key: string): Promise<number> {
+    return this.zsets.get(key)?.size ?? 0
   }
 }

--- a/packages/types/SystemEventTypes.ts
+++ b/packages/types/SystemEventTypes.ts
@@ -62,7 +62,11 @@ export type SystemEventHandlers = {
   }) => Promise<void> | void
 
   // Queue events
-  QUEUE_CHANGED: (data: { roomId: string; queue: QueueItem[] }) => Promise<void> | void
+  QUEUE_CHANGED: (data: {
+    roomId: string
+    queue: QueueItem[]
+    splitKey?: string | null
+  }) => Promise<void> | void
 
   // Event for when additional metadata arrives for an existing track (from secondary MetadataSources)
   TRACK_METADATA_UPDATED: (data: {


### PR DESCRIPTION
Adds the ability for admins to add a single split in the queue, where all new tracks are added above the split and everything below is preserved.

https://github.com/user-attachments/assets/8f8b9af3-d7a8-496f-a1d8-25f82757e569

