### PR TITLE
Admin quick access panels

### DIFF
--- a/apps/web/src/actors/index.ts
+++ b/apps/web/src/actors/index.ts
@@ -186,11 +186,7 @@ export {
 } from "./pollActor"
 
 // Quick Access Panels Actor
-export {
-  quickAccessPanelsActor,
-  getQuickAccessPanels,
-  getOpenQuickAccessPluginNames,
-} from "./quickAccessPanelsActor"
+export { quickAccessPanelsActor } from "./quickAccessPanelsActor"
 
 // Room Lifecycle
 export {

--- a/apps/web/src/actors/index.ts
+++ b/apps/web/src/actors/index.ts
@@ -185,6 +185,13 @@ export {
   getLastPollChange,
 } from "./pollActor"
 
+// Quick Access Panels Actor
+export {
+  quickAccessPanelsActor,
+  getQuickAccessPanels,
+  getOpenQuickAccessPluginNames,
+} from "./quickAccessPanelsActor"
+
 // Room Lifecycle
 export {
   initializeRoom,

--- a/apps/web/src/actors/quickAccessPanelsActor.ts
+++ b/apps/web/src/actors/quickAccessPanelsActor.ts
@@ -1,0 +1,21 @@
+/**
+ * Quick Access Panels Actor
+ *
+ * Room-scoped open set + desktop geometry for admin Quick Access FloatingPanels (ADR 0072).
+ * Send ACTIVATE { roomId } on room entry, DEACTIVATE on room exit (see roomLifecycle).
+ */
+
+import { createActor } from "xstate"
+import { quickAccessPanelsMachine } from "../machines/quickAccessPanelsMachine"
+
+export const quickAccessPanelsActor = createActor(quickAccessPanelsMachine).start()
+
+export function getQuickAccessPanels() {
+  return quickAccessPanelsActor.getSnapshot().context.panels
+}
+
+export function getOpenQuickAccessPluginNames(): string[] {
+  return Object.entries(quickAccessPanelsActor.getSnapshot().context.panels)
+    .filter(([, panel]) => panel.open)
+    .map(([name]) => name)
+}

--- a/apps/web/src/actors/quickAccessPanelsActor.ts
+++ b/apps/web/src/actors/quickAccessPanelsActor.ts
@@ -1,7 +1,7 @@
 /**
  * Quick Access Panels Actor
  *
- * Room-scoped open set + desktop geometry for admin Quick Access FloatingPanels (ADR 0072).
+ * Room-scoped open set for admin Quick Access FloatingPanels (ADR 0072).
  * Send ACTIVATE { roomId } on room entry, DEACTIVATE on room exit (see roomLifecycle).
  */
 
@@ -9,13 +9,3 @@ import { createActor } from "xstate"
 import { quickAccessPanelsMachine } from "../machines/quickAccessPanelsMachine"
 
 export const quickAccessPanelsActor = createActor(quickAccessPanelsMachine).start()
-
-export function getQuickAccessPanels() {
-  return quickAccessPanelsActor.getSnapshot().context.panels
-}
-
-export function getOpenQuickAccessPluginNames(): string[] {
-  return Object.entries(quickAccessPanelsActor.getSnapshot().context.panels)
-    .filter(([, panel]) => panel.open)
-    .map(([name]) => name)
-}

--- a/apps/web/src/actors/roomLifecycle.ts
+++ b/apps/web/src/actors/roomLifecycle.ts
@@ -24,6 +24,7 @@ import { metadataSourceAuthActor } from "./metadataSourceAuthActor"
 import { soundEffectsActor } from "./soundEffectsActor"
 import { screenEffectsActor } from "./screenEffectsActor"
 import { pollActor } from "./pollActor"
+import { quickAccessPanelsActor } from "./quickAccessPanelsActor"
 
 import {
   getPersistedRoomState,
@@ -96,6 +97,7 @@ export function initializeRoom(roomId: string): void {
   soundEffectsActor.send({ type: "ACTIVATE" })
   screenEffectsActor.send({ type: "ACTIVATE" })
   pollActor.send({ type: "ACTIVATE" })
+  quickAccessPanelsActor.send({ type: "ACTIVATE", roomId })
 
   // Start fetching room data
   fetchRoom(roomId)
@@ -147,6 +149,7 @@ export function teardownRoom(): void {
   soundEffectsActor.send({ type: "DEACTIVATE" })
   screenEffectsActor.send({ type: "DEACTIVATE" })
   pollActor.send({ type: "DEACTIVATE" })
+  quickAccessPanelsActor.send({ type: "DEACTIVATE" })
 
   currentRoomId = null
   isInitialized = false

--- a/apps/web/src/components/AdminControls.tsx
+++ b/apps/web/src/components/AdminControls.tsx
@@ -9,10 +9,10 @@ import {
   BoxProps,
   RecipeProps,
 } from "@chakra-ui/react"
-import { LuArrowLeft, LuSettings, LuBookmark } from "react-icons/lu"
-import { Link } from "@tanstack/react-router"
+import { LuSettings, LuBookmark } from "react-icons/lu"
 
 import { useBookmarks, useModalsSend } from "../hooks/useActors"
+import QuickAccessMenu from "./QuickAccessMenu"
 
 type ButtonVariant = RecipeProps<"button">["variant"]
 
@@ -57,6 +57,12 @@ function AdminPanel({ buttonColorScheme, buttonVariant = "bright", width, ...res
               <Icon as={LuSettings} />
             </IconButton>
           </Box>
+
+          <QuickAccessMenu
+            buttonColorScheme={buttonColorScheme}
+            buttonVariant={buttonVariant}
+          />
+
           <Box hideBelow="sm">
             <Button
               size="xs"

--- a/apps/web/src/components/Modals/Admin/Overview.tsx
+++ b/apps/web/src/components/Modals/Admin/Overview.tsx
@@ -26,26 +26,9 @@ import DestructiveActions from "./DestructiveActions"
 import ButtonRoomAuthSpotify from "../../ButtonRoomAuthSpotify"
 import ButtonRoomAuthTidal from "../../ButtonRoomAuthTidal"
 import { exportPreset, importPreset } from "../../../lib/pluginPresets"
+import { toPluginDisplayName } from "../../../lib/pluginDisplayName"
+import { toPluginSettingsEventType } from "../../../lib/pluginSettingsEvent"
 import { toaster } from "../../ui/toaster"
-
-/**
- * Convert plugin name to a display-friendly title
- * e.g., "playlist-democracy" -> "Playlist Democracy"
- */
-function toDisplayName(name: string): string {
-  return name
-    .split("-")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ")
-}
-
-/**
- * Convert plugin name to event name for modal state machine
- * e.g., "playlist-democracy" -> "EDIT_PLAYLIST_DEMOCRACY"
- */
-function toEventName(name: string): string {
-  return `EDIT_${name.replace(/-/g, "_").toUpperCase()}`
-}
 
 function Overview() {
   const send = useModalsSend()
@@ -278,9 +261,9 @@ function Overview() {
                     borderBottomRadius={
                       index === configurablePlugins.length - 1 ? undefined : "none"
                     }
-                    onClick={() => send({ type: toEventName(plugin.name) } as any)}
+                    onClick={() => send({ type: toPluginSettingsEventType(plugin.name) } as any)}
                   >
-                    {toDisplayName(plugin.name)}
+                    {toPluginDisplayName(plugin.name)}
                     <HStack>
                       {isPluginActive(plugin.name) && <ActiveIndicator />}
                       <LuChevronRight />

--- a/apps/web/src/components/Overlays.tsx
+++ b/apps/web/src/components/Overlays.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import { memo } from "react"
 import { Box } from "@chakra-ui/react"
 
 import DrawerBookmarks from "./Drawers/DrawerBookmarks"
@@ -15,7 +15,13 @@ import ScreenEffectsProvider from "./ScreenEffectsProvider"
 import { ModifierBlurLayer } from "./ModifierBlurLayer"
 import DrawerSchedule from "./Drawers/DrawerSchedule"
 import PollHistoryModal from "./Poll/PollHistoryModal"
+import QuickAccessPanels from "./QuickAccessPanels"
 
+/**
+ * Memoized so room-level re-renders (nowPlaying, listeners, etc.) do not tear down
+ * overlay trees. Sidebar is already memoized for the same reason — schedule notes
+ * FloatingPanels rely on that stability.
+ */
 function Overlays() {
   return (
     <div>
@@ -33,6 +39,7 @@ function Overlays() {
       <ModalPassword />
       <ModalUserGameState />
       <PollHistoryModal />
+      <QuickAccessPanels />
 
       {/* Timed modifier stacks (e.g. interface blur) */}
       <ModifierBlurLayer />
@@ -42,4 +49,4 @@ function Overlays() {
   )
 }
 
-export default Overlays
+export default memo(Overlays)

--- a/apps/web/src/components/QuickAccessMenu.tsx
+++ b/apps/web/src/components/QuickAccessMenu.tsx
@@ -10,7 +10,6 @@ import {
   RecipeProps,
   Text,
 } from "@chakra-ui/react"
-import { getQuickAccessSchema } from "@repo/plugin-config-ui"
 import { LuCheck, LuPanelTop, LuZap } from "react-icons/lu"
 import {
   usePluginConfigs,
@@ -19,6 +18,7 @@ import {
 } from "../hooks/useActors"
 import { usePluginSchemas } from "../hooks/usePluginSchemas"
 import { toPluginDisplayName } from "../lib/pluginDisplayName"
+import { listEnabledQuickAccessPlugins } from "../lib/quickAccessPlugins"
 
 type ButtonVariant = RecipeProps<"button">["variant"]
 
@@ -65,14 +65,10 @@ export default function QuickAccessMenu({ buttonColorScheme, buttonVariant = "su
   const quickAccessSend = useQuickAccessPanelsSend()
   const { schemas } = usePluginSchemas()
 
-  const quickAccessPlugins = useMemo(() => {
-    return schemas.filter((plugin) => {
-      const schema = plugin.configSchema
-      if (!schema?.quickAccess?.length) return false
-      if (!getQuickAccessSchema(schema)) return false
-      return pluginConfigs?.[plugin.name]?.enabled === true
-    })
-  }, [schemas, pluginConfigs])
+  const quickAccessPlugins = useMemo(
+    () => listEnabledQuickAccessPlugins(schemas, pluginConfigs),
+    [schemas, pluginConfigs],
+  )
 
   if (quickAccessPlugins.length === 0) return null
 

--- a/apps/web/src/components/QuickAccessMenu.tsx
+++ b/apps/web/src/components/QuickAccessMenu.tsx
@@ -1,0 +1,138 @@
+import { useMemo } from "react"
+import {
+  Box,
+  Button,
+  HStack,
+  Icon,
+  IconButton,
+  Menu,
+  Portal,
+  RecipeProps,
+  Text,
+} from "@chakra-ui/react"
+import { getQuickAccessSchema } from "@repo/plugin-config-ui"
+import { LuCheck, LuPanelTop, LuZap } from "react-icons/lu"
+import {
+  usePluginConfigs,
+  useQuickAccessPanels,
+  useQuickAccessPanelsSend,
+} from "../hooks/useActors"
+import { usePluginSchemas } from "../hooks/usePluginSchemas"
+import { toPluginDisplayName } from "../lib/pluginDisplayName"
+
+type ButtonVariant = RecipeProps<"button">["variant"]
+
+type Props = {
+  buttonColorScheme?: string
+  buttonVariant?: ButtonVariant
+}
+
+function QuickAccessMenuItems({
+  plugins,
+  panels,
+  onToggle,
+}: {
+  plugins: { name: string }[]
+  panels: Record<string, { open?: boolean } | undefined>
+  onToggle: (pluginName: string) => void
+}) {
+  return (
+    <>
+      {plugins.map((plugin) => {
+        const open = panels[plugin.name]?.open === true
+        return (
+          <Menu.Item
+            key={plugin.name}
+            value={plugin.name}
+            closeOnSelect={false}
+            onClick={() => onToggle(plugin.name)}
+          >
+            <HStack justify="space-between" w="100%" gap={3}>
+              <Text>{toPluginDisplayName(plugin.name)}</Text>
+              {open && <Icon as={LuCheck} aria-label="Panel open" />}
+            </HStack>
+          </Menu.Item>
+        )
+      })}
+    </>
+  )
+}
+
+/** Admin Quick Access plugin picker — portalled menu overlay (ADR 0072). */
+export default function QuickAccessMenu({ buttonColorScheme, buttonVariant = "subtle" }: Props) {
+  const pluginConfigs = usePluginConfigs()
+  const panels = useQuickAccessPanels()
+  const quickAccessSend = useQuickAccessPanelsSend()
+  const { schemas } = usePluginSchemas()
+
+  const quickAccessPlugins = useMemo(() => {
+    return schemas.filter((plugin) => {
+      const schema = plugin.configSchema
+      if (!schema?.quickAccess?.length) return false
+      if (!getQuickAccessSchema(schema)) return false
+      return pluginConfigs?.[plugin.name]?.enabled === true
+    })
+  }, [schemas, pluginConfigs])
+
+  if (quickAccessPlugins.length === 0) return null
+
+  const anyQuickAccessOpen = quickAccessPlugins.some((plugin) => panels[plugin.name]?.open)
+  const toggle = (pluginName: string) => quickAccessSend({ type: "TOGGLE", pluginName })
+
+  return (
+    <>
+      <Box hideBelow="sm">
+        <Menu.Root positioning={{ placement: "top-start", gutter: 4 }}>
+          <Menu.Trigger asChild>
+            <Button
+              size="xs"
+              variant={anyQuickAccessOpen ? "solid" : buttonVariant}
+              colorPalette={buttonColorScheme}
+              aria-pressed={anyQuickAccessOpen}
+            >
+              <Icon as={LuZap} />
+              Quick access
+            </Button>
+          </Menu.Trigger>
+          <Portal>
+            <Menu.Positioner>
+              <Menu.Content minW="220px">
+                <QuickAccessMenuItems
+                  plugins={quickAccessPlugins}
+                  panels={panels}
+                  onToggle={toggle}
+                />
+              </Menu.Content>
+            </Menu.Positioner>
+          </Portal>
+        </Menu.Root>
+      </Box>
+      <Box hideFrom="sm">
+        <Menu.Root positioning={{ placement: "top-start", gutter: 4 }}>
+          <Menu.Trigger asChild>
+            <IconButton
+              size="md"
+              variant={anyQuickAccessOpen ? "solid" : buttonVariant}
+              colorPalette={buttonColorScheme}
+              aria-label="Quick access"
+              aria-pressed={anyQuickAccessOpen}
+            >
+              <Icon as={LuPanelTop} />
+            </IconButton>
+          </Menu.Trigger>
+          <Portal>
+            <Menu.Positioner>
+              <Menu.Content minW="220px">
+                <QuickAccessMenuItems
+                  plugins={quickAccessPlugins}
+                  panels={panels}
+                  onToggle={toggle}
+                />
+              </Menu.Content>
+            </Menu.Positioner>
+          </Portal>
+        </Menu.Root>
+      </Box>
+    </>
+  )
+}

--- a/apps/web/src/components/QuickAccessPanels.tsx
+++ b/apps/web/src/components/QuickAccessPanels.tsx
@@ -1,0 +1,295 @@
+import { memo, useEffect, useMemo, useRef } from "react"
+import {
+  CloseButton,
+  DialogBackdrop,
+  DialogBody,
+  DialogCloseTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogPositioner,
+  DialogRoot,
+  FloatingPanel,
+  Icon,
+  IconButton,
+  useBreakpointValue,
+  VStack,
+} from "@chakra-ui/react"
+import { useSelector } from "@xstate/react"
+import { getQuickAccessSchema } from "@repo/plugin-config-ui"
+import { LuMaximize2, LuMinus, LuSettings, LuSquare, LuX } from "react-icons/lu"
+import {
+  getQuickAccessPanels,
+  quickAccessPanelsActor,
+} from "../actors/quickAccessPanelsActor"
+import {
+  useIsAdmin,
+  useModalsSend,
+  usePluginConfigs,
+  useQuickAccessPanelsSend,
+} from "../hooks/useActors"
+import { usePluginSchemas } from "../hooks/usePluginSchemas"
+import { toPluginDisplayName } from "../lib/pluginDisplayName"
+import { toPluginSettingsEventType } from "../lib/pluginSettingsEvent"
+import { QUICK_ACCESS_DEFAULT_SIZE } from "../machines/quickAccessPanelsMachine"
+import type { Event as ModalsEvent } from "../machines/modalsMachine"
+import PluginConfigForm from "./Modals/Admin/PluginConfigForm"
+
+function useOpenPluginSettings(pluginName: string) {
+  const modalSend = useModalsSend()
+  return () => {
+    modalSend({ type: toPluginSettingsEventType(pluginName) } as ModalsEvent)
+  }
+}
+
+/**
+ * Stable open-set fingerprint. Geometry-only SET_GEOMETRY updates must not change this,
+ * so the host can re-render without remounting/re-rendering FloatingPanel roots.
+ */
+function selectOpenPluginNamesKey(state: {
+  context: { panels: Record<string, { open?: boolean } | undefined> }
+}): string {
+  return Object.entries(state.context.panels)
+    .filter(([, panel]) => panel?.open === true)
+    .map(([name]) => name)
+    .sort()
+    .join("\0")
+}
+
+function PanelBody({
+  pluginName,
+  configSchema,
+  values,
+}: {
+  pluginName: string
+  configSchema: NonNullable<ReturnType<typeof getQuickAccessSchema>>
+  values: Record<string, unknown>
+}) {
+  return (
+    <PluginConfigForm
+      schema={configSchema}
+      values={values}
+      allValues={values}
+      onChange={() => {}}
+      pluginName={pluginName}
+    />
+  )
+}
+
+/**
+ * Self-contained desktop panel. Only takes `pluginName` so React.memo can skip re-renders
+ * when Room/Overlays update (nowPlaying, listeners, etc.).
+ *
+ * RoomSchedulePanel's FloatingPanels stay interactive because they live under memo(Sidebar).
+ * Quick Access mounts from Overlays (not memoized), so without this isolation zag's
+ * drag/resize/minimize state is torn down by constant parent re-renders.
+ */
+const DesktopPanel = memo(function DesktopPanel({ pluginName }: { pluginName: string }) {
+  const send = useQuickAccessPanelsSend()
+  const openPluginSettings = useOpenPluginSettings(pluginName)
+  const pluginConfigs = usePluginConfigs()
+  const { schemas } = usePluginSchemas()
+
+  const pluginSchema = schemas.find((schema) => schema.name === pluginName)
+  const configSchema =
+    pluginSchema?.configSchema && getQuickAccessSchema(pluginSchema.configSchema)
+
+  // Mount-only geometry — never read live actor size/position back into FloatingPanel props.
+  const initialGeometryRef = useRef<{
+    position: { x: number; y: number }
+    size: { width: number; height: number }
+  } | null>(null)
+  if (initialGeometryRef.current === null) {
+    const panel = getQuickAccessPanels()[pluginName]
+    initialGeometryRef.current = {
+      position: panel?.position ?? { x: 48, y: 72 },
+      size: panel?.size ?? { ...QUICK_ACCESS_DEFAULT_SIZE },
+    }
+  }
+
+  if (!configSchema || !pluginSchema) return null
+
+  const title = toPluginDisplayName(pluginName)
+  const values = {
+    ...(pluginSchema.defaultConfig ?? {}),
+    ...(pluginConfigs?.[pluginName] ?? {}),
+  }
+
+  return (
+    <FloatingPanel.Root
+      open
+      onOpenChange={(e) => {
+        if (!e.open) send({ type: "CLOSE", pluginName })
+      }}
+      defaultPosition={initialGeometryRef.current.position}
+      defaultSize={initialGeometryRef.current.size}
+      allowOverflow={false}
+      onPositionChangeEnd={(details) => {
+        send({ type: "SET_GEOMETRY", pluginName, position: details.position })
+      }}
+      onSizeChangeEnd={(details) => {
+        send({ type: "SET_GEOMETRY", pluginName, size: details.size })
+      }}
+    >
+      <FloatingPanel.Positioner>
+        <FloatingPanel.Content>
+          <FloatingPanel.Header>
+            <FloatingPanel.DragTrigger>
+              <FloatingPanel.Title>{title}</FloatingPanel.Title>
+            </FloatingPanel.DragTrigger>
+            <FloatingPanel.Control>
+              <IconButton
+                size="xs"
+                variant="ghost"
+                aria-label={`Open ${title} settings`}
+                onClick={openPluginSettings}
+              >
+                <Icon as={LuSettings} />
+              </IconButton>
+              <FloatingPanel.StageTrigger stage="minimized" asChild>
+                <IconButton size="xs" variant="ghost" aria-label="Minimize">
+                  <Icon as={LuMinus} />
+                </IconButton>
+              </FloatingPanel.StageTrigger>
+              <FloatingPanel.StageTrigger stage="maximized" asChild>
+                <IconButton size="xs" variant="ghost" aria-label="Maximize">
+                  <Icon as={LuMaximize2} />
+                </IconButton>
+              </FloatingPanel.StageTrigger>
+              <FloatingPanel.StageTrigger stage="default" asChild>
+                <IconButton size="xs" variant="ghost" aria-label="Restore">
+                  <Icon as={LuSquare} />
+                </IconButton>
+              </FloatingPanel.StageTrigger>
+              <FloatingPanel.CloseTrigger asChild>
+                <IconButton size="xs" variant="ghost" aria-label={`Close ${title}`}>
+                  <Icon as={LuX} />
+                </IconButton>
+              </FloatingPanel.CloseTrigger>
+            </FloatingPanel.Control>
+          </FloatingPanel.Header>
+          <FloatingPanel.Body>
+            <PanelBody pluginName={pluginName} configSchema={configSchema} values={values} />
+          </FloatingPanel.Body>
+          <FloatingPanel.ResizeTriggers />
+        </FloatingPanel.Content>
+      </FloatingPanel.Positioner>
+    </FloatingPanel.Root>
+  )
+})
+
+const MobilePanel = memo(function MobilePanel({ pluginName }: { pluginName: string }) {
+  const send = useQuickAccessPanelsSend()
+  const openPluginSettings = useOpenPluginSettings(pluginName)
+  const pluginConfigs = usePluginConfigs()
+  const { schemas } = usePluginSchemas()
+
+  const pluginSchema = schemas.find((schema) => schema.name === pluginName)
+  const configSchema =
+    pluginSchema?.configSchema && getQuickAccessSchema(pluginSchema.configSchema)
+
+  if (!configSchema || !pluginSchema) return null
+
+  const title = toPluginDisplayName(pluginName)
+  const values = {
+    ...(pluginSchema.defaultConfig ?? {}),
+    ...(pluginConfigs?.[pluginName] ?? {}),
+  }
+
+  return (
+    <DialogRoot
+      open
+      onOpenChange={(e) => {
+        if (!e.open) send({ type: "CLOSE", pluginName })
+      }}
+      placement="center"
+      size="full"
+    >
+      <DialogBackdrop />
+      <DialogPositioner>
+        <DialogContent>
+          <DialogHeader fontWeight="semibold" pr={16}>
+            {title}
+          </DialogHeader>
+          <IconButton
+            size="sm"
+            variant="ghost"
+            aria-label={`Open ${title} settings`}
+            position="absolute"
+            top="2"
+            right="10"
+            onClick={openPluginSettings}
+          >
+            <Icon as={LuSettings} />
+          </IconButton>
+          <DialogCloseTrigger asChild position="absolute" top="2" right="2">
+            <CloseButton size="sm" />
+          </DialogCloseTrigger>
+          <DialogBody>
+            <VStack align="stretch" gap={4}>
+              <PanelBody pluginName={pluginName} configSchema={configSchema} values={values} />
+            </VStack>
+          </DialogBody>
+        </DialogContent>
+      </DialogPositioner>
+    </DialogRoot>
+  )
+})
+
+/**
+ * Host for admin Quick Access FloatingPanels / mobile dialogs (ADR 0072).
+ * Mount once from Overlays so multiple AdminControls mounts share one panel tree.
+ */
+export default function QuickAccessPanels() {
+  const isAdmin = useIsAdmin()
+  const openKey = useSelector(quickAccessPanelsActor, selectOpenPluginNamesKey)
+  const send = useQuickAccessPanelsSend()
+  const pluginConfigs = usePluginConfigs()
+  const { schemas, isLoading: schemasLoading } = usePluginSchemas()
+  const isSmallScreen = useBreakpointValue({ base: true, md: false }) ?? false
+
+  const enabledQuickAccessKey = useMemo(() => {
+    return schemas
+      .filter((plugin) => {
+        const schema = plugin.configSchema
+        if (!schema?.quickAccess?.length) return false
+        if (!getQuickAccessSchema(schema)) return false
+        return pluginConfigs?.[plugin.name]?.enabled === true
+      })
+      .map((plugin) => plugin.name)
+      .sort()
+      .join("\0")
+  }, [schemas, pluginConfigs])
+
+  useEffect(() => {
+    if (!isAdmin || schemasLoading || schemas.length === 0) return
+    send({
+      type: "PRUNE",
+      enabledPluginNames: enabledQuickAccessKey ? enabledQuickAccessKey.split("\0") : [],
+    })
+  }, [isAdmin, schemasLoading, schemas.length, enabledQuickAccessKey, send])
+
+  const openNames = useMemo(
+    () => (openKey ? openKey.split("\0") : []),
+    [openKey],
+  )
+
+  if (!isAdmin || openNames.length === 0) return null
+
+  if (isSmallScreen) {
+    return (
+      <>
+        {openNames.map((pluginName) => (
+          <MobilePanel key={pluginName} pluginName={pluginName} />
+        ))}
+      </>
+    )
+  }
+
+  return (
+    <>
+      {openNames.map((pluginName) => (
+        <DesktopPanel key={pluginName} pluginName={pluginName} />
+      ))}
+    </>
+  )
+}

--- a/apps/web/src/components/QuickAccessPanels.tsx
+++ b/apps/web/src/components/QuickAccessPanels.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useRef } from "react"
+import { useEffect, useMemo } from "react"
 import {
   CloseButton,
   DialogBackdrop,
@@ -14,97 +14,37 @@ import {
   useBreakpointValue,
   VStack,
 } from "@chakra-ui/react"
-import { useSelector } from "@xstate/react"
 import { getQuickAccessSchema } from "@repo/plugin-config-ui"
 import { LuMaximize2, LuMinus, LuSettings, LuSquare, LuX } from "react-icons/lu"
-import {
-  getQuickAccessPanels,
-  quickAccessPanelsActor,
-} from "../actors/quickAccessPanelsActor"
 import {
   useIsAdmin,
   useModalsSend,
   usePluginConfigs,
+  useQuickAccessPanels,
   useQuickAccessPanelsSend,
 } from "../hooks/useActors"
 import { usePluginSchemas } from "../hooks/usePluginSchemas"
 import { toPluginDisplayName } from "../lib/pluginDisplayName"
 import { toPluginSettingsEventType } from "../lib/pluginSettingsEvent"
-import { QUICK_ACCESS_DEFAULT_SIZE } from "../machines/quickAccessPanelsMachine"
+import { listEnabledQuickAccessPlugins } from "../lib/quickAccessPlugins"
 import type { Event as ModalsEvent } from "../machines/modalsMachine"
 import PluginConfigForm from "./Modals/Admin/PluginConfigForm"
 
-function useOpenPluginSettings(pluginName: string) {
-  const modalSend = useModalsSend()
-  return () => {
-    modalSend({ type: toPluginSettingsEventType(pluginName) } as ModalsEvent)
-  }
+const PANEL_DEFAULT_SIZE = { width: 320, height: 360 }
+
+function cascadePosition(index: number) {
+  const offset = index * 28
+  return { x: 48 + offset, y: 72 + offset }
 }
 
-/**
- * Stable open-set fingerprint. Geometry-only SET_GEOMETRY updates must not change this,
- * so the host can re-render without remounting/re-rendering FloatingPanel roots.
- */
-function selectOpenPluginNamesKey(state: {
-  context: { panels: Record<string, { open?: boolean } | undefined> }
-}): string {
-  return Object.entries(state.context.panels)
-    .filter(([, panel]) => panel?.open === true)
-    .map(([name]) => name)
-    .sort()
-    .join("\0")
-}
-
-function PanelBody({
-  pluginName,
-  configSchema,
-  values,
-}: {
-  pluginName: string
-  configSchema: NonNullable<ReturnType<typeof getQuickAccessSchema>>
-  values: Record<string, unknown>
-}) {
-  return (
-    <PluginConfigForm
-      schema={configSchema}
-      values={values}
-      allValues={values}
-      onChange={() => {}}
-      pluginName={pluginName}
-    />
-  )
-}
-
-/**
- * Self-contained desktop panel. Only takes `pluginName` so React.memo can skip re-renders
- * when Room/Overlays update (nowPlaying, listeners, etc.).
- *
- * RoomSchedulePanel's FloatingPanels stay interactive because they live under memo(Sidebar).
- * Quick Access mounts from Overlays (not memoized), so without this isolation zag's
- * drag/resize/minimize state is torn down by constant parent re-renders.
- */
-const DesktopPanel = memo(function DesktopPanel({ pluginName }: { pluginName: string }) {
-  const send = useQuickAccessPanelsSend()
-  const openPluginSettings = useOpenPluginSettings(pluginName)
+function useQuickAccessPanelModel(pluginName: string) {
   const pluginConfigs = usePluginConfigs()
   const { schemas } = usePluginSchemas()
+  const modalSend = useModalsSend()
 
   const pluginSchema = schemas.find((schema) => schema.name === pluginName)
   const configSchema =
     pluginSchema?.configSchema && getQuickAccessSchema(pluginSchema.configSchema)
-
-  // Mount-only geometry — never read live actor size/position back into FloatingPanel props.
-  const initialGeometryRef = useRef<{
-    position: { x: number; y: number }
-    size: { width: number; height: number }
-  } | null>(null)
-  if (initialGeometryRef.current === null) {
-    const panel = getQuickAccessPanels()[pluginName]
-    initialGeometryRef.current = {
-      position: panel?.position ?? { x: 48, y: 72 },
-      size: panel?.size ?? { ...QUICK_ACCESS_DEFAULT_SIZE },
-    }
-  }
 
   if (!configSchema || !pluginSchema) return null
 
@@ -113,6 +53,25 @@ const DesktopPanel = memo(function DesktopPanel({ pluginName }: { pluginName: st
     ...(pluginSchema.defaultConfig ?? {}),
     ...(pluginConfigs?.[pluginName] ?? {}),
   }
+  const openSettings = () => {
+    modalSend({ type: toPluginSettingsEventType(pluginName) } as ModalsEvent)
+  }
+
+  return { title, values, configSchema, openSettings }
+}
+
+function DesktopPanel({
+  pluginName,
+  defaultPosition,
+}: {
+  pluginName: string
+  defaultPosition: { x: number; y: number }
+}) {
+  const send = useQuickAccessPanelsSend()
+  const model = useQuickAccessPanelModel(pluginName)
+  if (!model) return null
+
+  const { title, values, configSchema, openSettings } = model
 
   return (
     <FloatingPanel.Root
@@ -120,15 +79,9 @@ const DesktopPanel = memo(function DesktopPanel({ pluginName }: { pluginName: st
       onOpenChange={(e) => {
         if (!e.open) send({ type: "CLOSE", pluginName })
       }}
-      defaultPosition={initialGeometryRef.current.position}
-      defaultSize={initialGeometryRef.current.size}
+      defaultPosition={defaultPosition}
+      defaultSize={PANEL_DEFAULT_SIZE}
       allowOverflow={false}
-      onPositionChangeEnd={(details) => {
-        send({ type: "SET_GEOMETRY", pluginName, position: details.position })
-      }}
-      onSizeChangeEnd={(details) => {
-        send({ type: "SET_GEOMETRY", pluginName, size: details.size })
-      }}
     >
       <FloatingPanel.Positioner>
         <FloatingPanel.Content>
@@ -141,7 +94,7 @@ const DesktopPanel = memo(function DesktopPanel({ pluginName }: { pluginName: st
                 size="xs"
                 variant="ghost"
                 aria-label={`Open ${title} settings`}
-                onClick={openPluginSettings}
+                onClick={openSettings}
               >
                 <Icon as={LuSettings} />
               </IconButton>
@@ -168,32 +121,27 @@ const DesktopPanel = memo(function DesktopPanel({ pluginName }: { pluginName: st
             </FloatingPanel.Control>
           </FloatingPanel.Header>
           <FloatingPanel.Body>
-            <PanelBody pluginName={pluginName} configSchema={configSchema} values={values} />
+            <PluginConfigForm
+              schema={configSchema}
+              values={values}
+              allValues={values}
+              onChange={() => {}}
+              pluginName={pluginName}
+            />
           </FloatingPanel.Body>
           <FloatingPanel.ResizeTriggers />
         </FloatingPanel.Content>
       </FloatingPanel.Positioner>
     </FloatingPanel.Root>
   )
-})
+}
 
-const MobilePanel = memo(function MobilePanel({ pluginName }: { pluginName: string }) {
+function MobilePanel({ pluginName }: { pluginName: string }) {
   const send = useQuickAccessPanelsSend()
-  const openPluginSettings = useOpenPluginSettings(pluginName)
-  const pluginConfigs = usePluginConfigs()
-  const { schemas } = usePluginSchemas()
+  const model = useQuickAccessPanelModel(pluginName)
+  if (!model) return null
 
-  const pluginSchema = schemas.find((schema) => schema.name === pluginName)
-  const configSchema =
-    pluginSchema?.configSchema && getQuickAccessSchema(pluginSchema.configSchema)
-
-  if (!configSchema || !pluginSchema) return null
-
-  const title = toPluginDisplayName(pluginName)
-  const values = {
-    ...(pluginSchema.defaultConfig ?? {}),
-    ...(pluginConfigs?.[pluginName] ?? {}),
-  }
+  const { title, values, configSchema, openSettings } = model
 
   return (
     <DialogRoot
@@ -217,7 +165,7 @@ const MobilePanel = memo(function MobilePanel({ pluginName }: { pluginName: stri
             position="absolute"
             top="2"
             right="10"
-            onClick={openPluginSettings}
+            onClick={openSettings}
           >
             <Icon as={LuSettings} />
           </IconButton>
@@ -226,51 +174,52 @@ const MobilePanel = memo(function MobilePanel({ pluginName }: { pluginName: stri
           </DialogCloseTrigger>
           <DialogBody>
             <VStack align="stretch" gap={4}>
-              <PanelBody pluginName={pluginName} configSchema={configSchema} values={values} />
+              <PluginConfigForm
+                schema={configSchema}
+                values={values}
+                allValues={values}
+                onChange={() => {}}
+                pluginName={pluginName}
+              />
             </VStack>
           </DialogBody>
         </DialogContent>
       </DialogPositioner>
     </DialogRoot>
   )
-})
+}
 
 /**
  * Host for admin Quick Access FloatingPanels / mobile dialogs (ADR 0072).
  * Mount once from Overlays so multiple AdminControls mounts share one panel tree.
+ * Stability comes from memo(Overlays), same pattern as memo(Sidebar) for schedule notes.
  */
 export default function QuickAccessPanels() {
   const isAdmin = useIsAdmin()
-  const openKey = useSelector(quickAccessPanelsActor, selectOpenPluginNamesKey)
+  const panels = useQuickAccessPanels()
   const send = useQuickAccessPanelsSend()
   const pluginConfigs = usePluginConfigs()
   const { schemas, isLoading: schemasLoading } = usePluginSchemas()
   const isSmallScreen = useBreakpointValue({ base: true, md: false }) ?? false
 
-  const enabledQuickAccessKey = useMemo(() => {
-    return schemas
-      .filter((plugin) => {
-        const schema = plugin.configSchema
-        if (!schema?.quickAccess?.length) return false
-        if (!getQuickAccessSchema(schema)) return false
-        return pluginConfigs?.[plugin.name]?.enabled === true
-      })
-      .map((plugin) => plugin.name)
-      .sort()
-      .join("\0")
-  }, [schemas, pluginConfigs])
+  const enabledPlugins = useMemo(
+    () => listEnabledQuickAccessPlugins(schemas, pluginConfigs),
+    [schemas, pluginConfigs],
+  )
+
+  const enabledPluginNames = useMemo(
+    () => enabledPlugins.map((plugin) => plugin.name),
+    [enabledPlugins],
+  )
 
   useEffect(() => {
     if (!isAdmin || schemasLoading || schemas.length === 0) return
-    send({
-      type: "PRUNE",
-      enabledPluginNames: enabledQuickAccessKey ? enabledQuickAccessKey.split("\0") : [],
-    })
-  }, [isAdmin, schemasLoading, schemas.length, enabledQuickAccessKey, send])
+    send({ type: "PRUNE", enabledPluginNames })
+  }, [isAdmin, schemasLoading, schemas.length, enabledPluginNames, send])
 
   const openNames = useMemo(
-    () => (openKey ? openKey.split("\0") : []),
-    [openKey],
+    () => Object.entries(panels).filter(([, panel]) => panel.open).map(([name]) => name),
+    [panels],
   )
 
   if (!isAdmin || openNames.length === 0) return null
@@ -287,8 +236,12 @@ export default function QuickAccessPanels() {
 
   return (
     <>
-      {openNames.map((pluginName) => (
-        <DesktopPanel key={pluginName} pluginName={pluginName} />
+      {openNames.map((pluginName, index) => (
+        <DesktopPanel
+          key={pluginName}
+          pluginName={pluginName}
+          defaultPosition={cascadePosition(index)}
+        />
       ))}
     </>
   )

--- a/apps/web/src/hooks/useActors.ts
+++ b/apps/web/src/hooks/useActors.ts
@@ -44,6 +44,7 @@ import { chatScrollTargetActor } from "../actors/chatScrollTargetActor"
 import { metadataPreferenceActor } from "../actors/metadataPreferenceActor"
 import { lobbyActor } from "../actors/lobbyActor"
 import { pollActor } from "../actors/pollActor"
+import { quickAccessPanelsActor } from "../actors/quickAccessPanelsActor"
 import type { RoomScheduleSnapshotDTO } from "@repo/types"
 import { MetadataSourceType, QueueItem } from "../types/Queue"
 
@@ -85,6 +86,7 @@ const sendToMetadataPreference = boundSendRef(metadataPreferenceActor)
 const sendToLobby = boundSendRef(lobbyActor)
 const sendToAdminListener = boundSendRef(adminListenerStateActor)
 const sendToPoll = boundSendRef(pollActor)
+const sendToQuickAccessPanels = boundSendRef(quickAccessPanelsActor)
 
 // ============================================================================
 // Auth Hooks
@@ -684,6 +686,16 @@ export const useVotePending = () => {
 }
 
 export const usePollSend = () => sendToPoll
+
+// ============================================================================
+// Quick Access Panels Hooks
+// ============================================================================
+
+export const useQuickAccessPanels = () => {
+  return useSelector(quickAccessPanelsActor, (s) => s.context.panels)
+}
+
+export const useQuickAccessPanelsSend = () => sendToQuickAccessPanels
 
 // ============================================================================
 // Lobby Hooks

--- a/apps/web/src/lib/pluginDisplayName.ts
+++ b/apps/web/src/lib/pluginDisplayName.ts
@@ -1,0 +1,7 @@
+/** Humanize a plugin package name for admin UI labels (e.g. "guess-the-tune" → "Guess The Tune"). */
+export function toPluginDisplayName(name: string): string {
+  return name
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ")
+}

--- a/apps/web/src/lib/pluginSettingsEvent.ts
+++ b/apps/web/src/lib/pluginSettingsEvent.ts
@@ -1,0 +1,7 @@
+/**
+ * Convert plugin name to modalsMachine event for that plugin's settings page.
+ * e.g. "playlist-democracy" -> "EDIT_PLAYLIST_DEMOCRACY"
+ */
+export function toPluginSettingsEventType(pluginName: string): string {
+  return `EDIT_${pluginName.replace(/-/g, "_").toUpperCase()}`
+}

--- a/apps/web/src/lib/quickAccessPlugins.ts
+++ b/apps/web/src/lib/quickAccessPlugins.ts
@@ -1,0 +1,18 @@
+import { getQuickAccessSchema } from "@repo/plugin-config-ui"
+import type { PluginSchemaInfo } from "@repo/types/Plugin"
+
+/**
+ * Plugins that appear in the Quick Access menu: declare resolvable `quickAccess`
+ * actions and have `enabled: true` in room config.
+ */
+export function listEnabledQuickAccessPlugins(
+  schemas: PluginSchemaInfo[],
+  pluginConfigs: Record<string, Record<string, unknown> | undefined> | null | undefined,
+): PluginSchemaInfo[] {
+  return schemas.filter((plugin) => {
+    const schema = plugin.configSchema
+    if (!schema?.quickAccess?.length) return false
+    if (!getQuickAccessSchema(schema)) return false
+    return pluginConfigs?.[plugin.name]?.enabled === true
+  })
+}

--- a/apps/web/src/machines/modalsMachine.ts
+++ b/apps/web/src/machines/modalsMachine.ts
@@ -37,8 +37,15 @@ export type Event =
   | { type: "EDIT_ITEM_SHOPS" }
   | { type: "EDIT_QUEUE_PACER" }
   | { type: "EDIT_QUIZ_SESSIONS" }
+  | { type: "EDIT_VOLUME_MANAGER" }
   | { type: "NEXT" }
   | { type: "NUKE_USER" }
+
+/** Jump to a settings section from any top-level modal state (admin only). */
+const openSettingsSection = (target: string) => ({
+  target: `.settings.${target}`,
+  guard: "isAdmin" as const,
+})
 
 export const modalsMachine = setup({
   types: {
@@ -71,6 +78,26 @@ export const modalsMachine = setup({
       target: ".settings",
       guard: "isAdmin",
     },
+    // Deep-link into settings sections / plugin pages (e.g. Quick Access → plugin config)
+    EDIT_CONTENT: openSettingsSection("content"),
+    EDIT_CHAT: openSettingsSection("chat"),
+    EDIT_DJ: openSettingsSection("dj"),
+    EDIT_SPOTIFY: openSettingsSection("spotify"),
+    EDIT_PASSWORD: openSettingsSection("password"),
+    EDIT_SCHEDULE: openSettingsSection("schedule"),
+    EDIT_GAME_SESSIONS: openSettingsSection("game_sessions"),
+    EDIT_POLLS: openSettingsSection("polls"),
+    EDIT_PLAYLIST_DEMOCRACY: openSettingsSection("playlist_democracy"),
+    EDIT_SPECIAL_WORDS: openSettingsSection("special_words"),
+    EDIT_ABSENT_DJ: openSettingsSection("absent_dj"),
+    EDIT_QUEUE_HYGIENE: openSettingsSection("queue_hygiene"),
+    EDIT_GUESS_THE_TUNE: openSettingsSection("guess_the_tune"),
+    EDIT_MUSIC_SHOP: openSettingsSection("music_shop"),
+    EDIT_LOYALTY_PROGRAM: openSettingsSection("loyalty_program"),
+    EDIT_ITEM_SHOPS: openSettingsSection("item_shops"),
+    EDIT_QUEUE_PACER: openSettingsSection("queue_pacer"),
+    EDIT_QUIZ_SESSIONS: openSettingsSection("quiz_sessions"),
+    EDIT_VOLUME_MANAGER: openSettingsSection("volume_manager"),
     VIEW_HELP: {
       target: ".help",
     },
@@ -109,31 +136,30 @@ export const modalsMachine = setup({
     settings: {
       entry: ["fetchSettings"],
       initial: "overview",
+      on: {
+        // Allow jumping between settings pages from any settings substate
+        EDIT_CONTENT: ".content",
+        EDIT_CHAT: ".chat",
+        EDIT_DJ: ".dj",
+        EDIT_SPOTIFY: ".spotify",
+        EDIT_PASSWORD: ".password",
+        EDIT_SCHEDULE: ".schedule",
+        EDIT_GAME_SESSIONS: ".game_sessions",
+        EDIT_POLLS: ".polls",
+        EDIT_PLAYLIST_DEMOCRACY: ".playlist_democracy",
+        EDIT_SPECIAL_WORDS: ".special_words",
+        EDIT_ABSENT_DJ: ".absent_dj",
+        EDIT_QUEUE_HYGIENE: ".queue_hygiene",
+        EDIT_GUESS_THE_TUNE: ".guess_the_tune",
+        EDIT_MUSIC_SHOP: ".music_shop",
+        EDIT_LOYALTY_PROGRAM: ".loyalty_program",
+        EDIT_ITEM_SHOPS: ".item_shops",
+        EDIT_QUEUE_PACER: ".queue_pacer",
+        EDIT_QUIZ_SESSIONS: ".quiz_sessions",
+        EDIT_VOLUME_MANAGER: ".volume_manager",
+      },
       states: {
-        overview: {
-          on: {
-            EDIT_CONTENT: "content",
-            EDIT_CHAT: "chat",
-            EDIT_DJ: "dj",
-            EDIT_SPOTIFY: "spotify",
-            EDIT_PASSWORD: "password",
-            EDIT_SCHEDULE: "schedule",
-            EDIT_GAME_SESSIONS: "game_sessions",
-            EDIT_POLLS: "polls",
-            // Plugin rows in Overview use EDIT_{NAME} (see toEventName); each needs a transition + substate below.
-            EDIT_PLAYLIST_DEMOCRACY: "playlist_democracy",
-            EDIT_SPECIAL_WORDS: "special_words",
-            EDIT_ABSENT_DJ: "absent_dj",
-            EDIT_QUEUE_HYGIENE: "queue_hygiene",
-            EDIT_GUESS_THE_TUNE: "guess_the_tune",
-            EDIT_MUSIC_SHOP: "music_shop",
-            EDIT_LOYALTY_PROGRAM: "loyalty_program",
-            EDIT_ITEM_SHOPS: "item_shops",
-            EDIT_QUEUE_PACER: "queue_pacer",
-            EDIT_QUIZ_SESSIONS: "quiz_sessions",
-            EDIT_VOLUME_MANAGER: "volume_manager",
-          },
-        },
+        overview: {},
         playlist_democracy: {
           on: {
             BACK: "overview",

--- a/apps/web/src/machines/quickAccessPanelsMachine.test.ts
+++ b/apps/web/src/machines/quickAccessPanelsMachine.test.ts
@@ -1,0 +1,97 @@
+import { createActor } from "xstate"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import {
+  loadQuickAccessPanels,
+  quickAccessPanelsMachine,
+  saveQuickAccessPanels,
+} from "./quickAccessPanelsMachine"
+
+const ROOM = "room-qa-test"
+
+function installSessionStorageMock() {
+  const store = new Map<string, string>()
+  const mock = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value)
+    },
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => {
+      store.clear()
+    },
+    key: (index: number) => [...store.keys()][index] ?? null,
+    get length() {
+      return store.size
+    },
+  }
+  Object.defineProperty(globalThis, "sessionStorage", {
+    value: mock,
+    configurable: true,
+    writable: true,
+  })
+}
+
+describe("quickAccessPanelsMachine", () => {
+  beforeEach(() => {
+    installSessionStorageMock()
+  })
+
+  afterEach(() => {
+    sessionStorage.clear()
+  })
+
+  it("hydrates open panels and geometry from sessionStorage on ACTIVATE", () => {
+    saveQuickAccessPanels(ROOM, {
+      "quiz-sessions": {
+        open: true,
+        position: { x: 100, y: 120 },
+        size: { width: 400, height: 500 },
+      },
+    })
+
+    const actor = createActor(quickAccessPanelsMachine).start()
+    actor.send({ type: "ACTIVATE", roomId: ROOM })
+
+    expect(actor.getSnapshot().context.panels["quiz-sessions"]).toEqual({
+      open: true,
+      position: { x: 100, y: 120 },
+      size: { width: 400, height: 500 },
+    })
+    actor.stop()
+  })
+
+  it("persists toggle open/close and retains geometry on close", () => {
+    const actor = createActor(quickAccessPanelsMachine).start()
+    actor.send({ type: "ACTIVATE", roomId: ROOM })
+    actor.send({ type: "TOGGLE", pluginName: "item-shops" })
+    actor.send({
+      type: "SET_GEOMETRY",
+      pluginName: "item-shops",
+      position: { x: 10, y: 20 },
+      size: { width: 300, height: 350 },
+    })
+    actor.send({ type: "CLOSE", pluginName: "item-shops" })
+
+    const stored = loadQuickAccessPanels(ROOM)
+    expect(stored["item-shops"]).toEqual({
+      open: false,
+      position: { x: 10, y: 20 },
+      size: { width: 300, height: 350 },
+    })
+    actor.stop()
+  })
+
+  it("prunes disabled plugins from persisted map", () => {
+    const actor = createActor(quickAccessPanelsMachine).start()
+    actor.send({ type: "ACTIVATE", roomId: ROOM })
+    actor.send({ type: "TOGGLE", pluginName: "quiz-sessions" })
+    actor.send({ type: "TOGGLE", pluginName: "item-shops" })
+    actor.send({ type: "PRUNE", enabledPluginNames: ["quiz-sessions"] })
+
+    expect(Object.keys(actor.getSnapshot().context.panels)).toEqual(["quiz-sessions"])
+    expect(loadQuickAccessPanels(ROOM)["item-shops"]).toBeUndefined()
+    actor.stop()
+  })
+})

--- a/apps/web/src/machines/quickAccessPanelsMachine.test.ts
+++ b/apps/web/src/machines/quickAccessPanelsMachine.test.ts
@@ -42,44 +42,32 @@ describe("quickAccessPanelsMachine", () => {
     sessionStorage.clear()
   })
 
-  it("hydrates open panels and geometry from sessionStorage on ACTIVATE", () => {
-    saveQuickAccessPanels(ROOM, {
-      "quiz-sessions": {
-        open: true,
-        position: { x: 100, y: 120 },
-        size: { width: 400, height: 500 },
-      },
-    })
+  it("hydrates open panels from sessionStorage on ACTIVATE (ignores legacy geometry)", () => {
+    sessionStorage.setItem(
+      `quickAccessPanels:${ROOM}`,
+      JSON.stringify({
+        "quiz-sessions": {
+          open: true,
+          position: { x: 100, y: 120 },
+          size: { width: 400, height: 500 },
+        },
+      }),
+    )
 
     const actor = createActor(quickAccessPanelsMachine).start()
     actor.send({ type: "ACTIVATE", roomId: ROOM })
 
-    expect(actor.getSnapshot().context.panels["quiz-sessions"]).toEqual({
-      open: true,
-      position: { x: 100, y: 120 },
-      size: { width: 400, height: 500 },
-    })
+    expect(actor.getSnapshot().context.panels["quiz-sessions"]).toEqual({ open: true })
     actor.stop()
   })
 
-  it("persists toggle open/close and retains geometry on close", () => {
+  it("persists toggle open/close without geometry", () => {
     const actor = createActor(quickAccessPanelsMachine).start()
     actor.send({ type: "ACTIVATE", roomId: ROOM })
     actor.send({ type: "TOGGLE", pluginName: "item-shops" })
-    actor.send({
-      type: "SET_GEOMETRY",
-      pluginName: "item-shops",
-      position: { x: 10, y: 20 },
-      size: { width: 300, height: 350 },
-    })
     actor.send({ type: "CLOSE", pluginName: "item-shops" })
 
-    const stored = loadQuickAccessPanels(ROOM)
-    expect(stored["item-shops"]).toEqual({
-      open: false,
-      position: { x: 10, y: 20 },
-      size: { width: 300, height: 350 },
-    })
+    expect(loadQuickAccessPanels(ROOM)["item-shops"]).toEqual({ open: false })
     actor.stop()
   })
 
@@ -93,5 +81,14 @@ describe("quickAccessPanelsMachine", () => {
     expect(Object.keys(actor.getSnapshot().context.panels)).toEqual(["quiz-sessions"])
     expect(loadQuickAccessPanels(ROOM)["item-shops"]).toBeUndefined()
     actor.stop()
+  })
+
+  it("saveQuickAccessPanels strips geometry from stored JSON", () => {
+    saveQuickAccessPanels(ROOM, {
+      "quiz-sessions": { open: true },
+    })
+    expect(JSON.parse(sessionStorage.getItem(`quickAccessPanels:${ROOM}`)!)).toEqual({
+      "quiz-sessions": { open: true },
+    })
   })
 })

--- a/apps/web/src/machines/quickAccessPanelsMachine.ts
+++ b/apps/web/src/machines/quickAccessPanelsMachine.ts
@@ -1,0 +1,256 @@
+import { assign, setup } from "xstate"
+
+const STORAGE_PREFIX = "quickAccessPanels:"
+
+export const QUICK_ACCESS_DEFAULT_SIZE = { width: 320, height: 360 }
+
+/** Reject sizes that can't be a usable panel (e.g. leftover minimized heights). */
+const MIN_PERSISTED_WIDTH = 200
+const MIN_PERSISTED_HEIGHT = 120
+
+export type QuickAccessPanelGeometry = {
+  position?: { x: number; y: number }
+  size?: { width: number; height: number }
+}
+
+export type QuickAccessPanelState = QuickAccessPanelGeometry & {
+  open: boolean
+}
+
+export type QuickAccessPanelsMap = Record<string, QuickAccessPanelState>
+
+export interface QuickAccessPanelsMachineContext {
+  roomId: string | null
+  panels: QuickAccessPanelsMap
+}
+
+export type QuickAccessPanelsEvent =
+  | { type: "ACTIVATE"; roomId: string }
+  | { type: "DEACTIVATE" }
+  | { type: "TOGGLE"; pluginName: string }
+  | { type: "CLOSE"; pluginName: string }
+  | {
+      type: "SET_GEOMETRY"
+      pluginName: string
+      position?: { x: number; y: number }
+      size?: { width: number; height: number }
+    }
+  | { type: "PRUNE"; enabledPluginNames: string[] }
+
+function isFiniteNumber(n: unknown): n is number {
+  return typeof n === "number" && Number.isFinite(n)
+}
+
+function parsePanelState(raw: unknown): QuickAccessPanelState | null {
+  if (!raw || typeof raw !== "object") return null
+  const obj = raw as Record<string, unknown>
+  if (typeof obj.open !== "boolean") return null
+
+  const position =
+    obj.position &&
+    typeof obj.position === "object" &&
+    isFiniteNumber((obj.position as { x?: unknown }).x) &&
+    isFiniteNumber((obj.position as { y?: unknown }).y)
+      ? { x: (obj.position as { x: number }).x, y: (obj.position as { y: number }).y }
+      : undefined
+
+  let size: { width: number; height: number } | undefined
+  if (
+    obj.size &&
+    typeof obj.size === "object" &&
+    isFiniteNumber((obj.size as { width?: unknown }).width) &&
+    isFiniteNumber((obj.size as { height?: unknown }).height)
+  ) {
+    const width = (obj.size as { width: number }).width
+    const height = (obj.size as { height: number }).height
+    if (width >= MIN_PERSISTED_WIDTH && height >= MIN_PERSISTED_HEIGHT) {
+      size = { width, height }
+    }
+  }
+
+  return { open: obj.open, ...(position ? { position } : {}), ...(size ? { size } : {}) }
+}
+
+export function loadQuickAccessPanels(roomId: string | null): QuickAccessPanelsMap {
+  if (roomId == null || typeof sessionStorage === "undefined") return {}
+  try {
+    const raw = sessionStorage.getItem(STORAGE_PREFIX + roomId)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {}
+    const result: QuickAccessPanelsMap = {}
+    for (const [name, value] of Object.entries(parsed as Record<string, unknown>)) {
+      const panel = parsePanelState(value)
+      if (panel) result[name] = panel
+    }
+    return result
+  } catch {
+    return {}
+  }
+}
+
+export function saveQuickAccessPanels(roomId: string | null, panels: QuickAccessPanelsMap): void {
+  if (roomId == null || typeof sessionStorage === "undefined") return
+  sessionStorage.setItem(STORAGE_PREFIX + roomId, JSON.stringify(panels))
+}
+
+function countOpenPanels(panels: QuickAccessPanelsMap): number {
+  return Object.values(panels).filter((p) => p.open).length
+}
+
+function cascadePosition(openCount: number): { x: number; y: number } {
+  const offset = openCount * 28
+  return { x: 48 + offset, y: 72 + offset }
+}
+
+function isUsablePosition(position: { x: number; y: number } | undefined): boolean {
+  if (!position) return false
+  if (typeof window === "undefined") return true
+  const { innerWidth, innerHeight } = window
+  // Require at least part of the panel header to remain on-screen.
+  return (
+    position.x > -200 &&
+    position.y > -40 &&
+    position.x < innerWidth - 40 &&
+    position.y < innerHeight - 40
+  )
+}
+
+export const quickAccessPanelsMachine = setup({
+  types: {
+    context: {} as QuickAccessPanelsMachineContext,
+    events: {} as QuickAccessPanelsEvent,
+  },
+  actions: {
+    persistPanels: ({ context }) => {
+      saveQuickAccessPanels(context.roomId, context.panels)
+    },
+    activateRoom: assign(({ event }) => {
+      if (event.type !== "ACTIVATE") return {}
+      return {
+        roomId: event.roomId,
+        panels: loadQuickAccessPanels(event.roomId),
+      }
+    }),
+    deactivateRoom: assign(() => ({
+      roomId: null,
+      panels: {} as QuickAccessPanelsMap,
+    })),
+    togglePanel: assign(({ context, event }) => {
+      if (event.type !== "TOGGLE") return {}
+      const { pluginName } = event
+      const existing = context.panels[pluginName]
+      if (existing?.open) {
+        return {
+          panels: {
+            ...context.panels,
+            [pluginName]: { ...existing, open: false },
+          },
+        }
+      }
+
+      const openCount = countOpenPanels(context.panels)
+      const storedPosition = existing?.position
+      const position = isUsablePosition(storedPosition)
+        ? storedPosition
+        : cascadePosition(openCount)
+
+      return {
+        panels: {
+          ...context.panels,
+          [pluginName]: {
+            open: true,
+            position,
+            size: existing?.size ?? { ...QUICK_ACCESS_DEFAULT_SIZE },
+          },
+        },
+      }
+    }),
+    closePanel: assign(({ context, event }) => {
+      if (event.type !== "CLOSE") return {}
+      const existing = context.panels[event.pluginName]
+      if (!existing) return {}
+      return {
+        panels: {
+          ...context.panels,
+          [event.pluginName]: { ...existing, open: false },
+        },
+      }
+    }),
+    setGeometry: assign(({ context, event }) => {
+      if (event.type !== "SET_GEOMETRY") return {}
+      const existing = context.panels[event.pluginName] ?? { open: true }
+      const nextSize =
+        event.size &&
+        event.size.width >= MIN_PERSISTED_WIDTH &&
+        event.size.height >= MIN_PERSISTED_HEIGHT
+          ? event.size
+          : undefined
+      return {
+        panels: {
+          ...context.panels,
+          [event.pluginName]: {
+            ...existing,
+            ...(event.position ? { position: event.position } : {}),
+            ...(nextSize ? { size: nextSize } : {}),
+          },
+        },
+      }
+    }),
+    prunePanels: assign(({ context, event }) => {
+      if (event.type !== "PRUNE") return {}
+      const allowed = new Set(event.enabledPluginNames)
+      let changed = false
+      const next: QuickAccessPanelsMap = {}
+      for (const [name, panel] of Object.entries(context.panels)) {
+        if (allowed.has(name)) {
+          next[name] = panel
+        } else {
+          changed = true
+        }
+      }
+      if (!changed) return {}
+      return { panels: next }
+    }),
+  },
+}).createMachine({
+  id: "quickAccessPanels",
+  context: {
+    roomId: null,
+    panels: {},
+  },
+  initial: "inactive",
+  states: {
+    inactive: {
+      on: {
+        ACTIVATE: {
+          target: "active",
+          actions: "activateRoom",
+        },
+      },
+    },
+    active: {
+      on: {
+        ACTIVATE: {
+          actions: ["activateRoom", "persistPanels"],
+        },
+        DEACTIVATE: {
+          target: "inactive",
+          actions: "deactivateRoom",
+        },
+        TOGGLE: {
+          actions: ["togglePanel", "persistPanels"],
+        },
+        CLOSE: {
+          actions: ["closePanel", "persistPanels"],
+        },
+        SET_GEOMETRY: {
+          actions: ["setGeometry", "persistPanels"],
+        },
+        PRUNE: {
+          actions: ["prunePanels", "persistPanels"],
+        },
+      },
+    },
+  },
+})

--- a/apps/web/src/machines/quickAccessPanelsMachine.ts
+++ b/apps/web/src/machines/quickAccessPanelsMachine.ts
@@ -2,18 +2,7 @@ import { assign, setup } from "xstate"
 
 const STORAGE_PREFIX = "quickAccessPanels:"
 
-export const QUICK_ACCESS_DEFAULT_SIZE = { width: 320, height: 360 }
-
-/** Reject sizes that can't be a usable panel (e.g. leftover minimized heights). */
-const MIN_PERSISTED_WIDTH = 200
-const MIN_PERSISTED_HEIGHT = 120
-
-export type QuickAccessPanelGeometry = {
-  position?: { x: number; y: number }
-  size?: { width: number; height: number }
-}
-
-export type QuickAccessPanelState = QuickAccessPanelGeometry & {
+export type QuickAccessPanelState = {
   open: boolean
 }
 
@@ -29,46 +18,13 @@ export type QuickAccessPanelsEvent =
   | { type: "DEACTIVATE" }
   | { type: "TOGGLE"; pluginName: string }
   | { type: "CLOSE"; pluginName: string }
-  | {
-      type: "SET_GEOMETRY"
-      pluginName: string
-      position?: { x: number; y: number }
-      size?: { width: number; height: number }
-    }
   | { type: "PRUNE"; enabledPluginNames: string[] }
-
-function isFiniteNumber(n: unknown): n is number {
-  return typeof n === "number" && Number.isFinite(n)
-}
 
 function parsePanelState(raw: unknown): QuickAccessPanelState | null {
   if (!raw || typeof raw !== "object") return null
   const obj = raw as Record<string, unknown>
   if (typeof obj.open !== "boolean") return null
-
-  const position =
-    obj.position &&
-    typeof obj.position === "object" &&
-    isFiniteNumber((obj.position as { x?: unknown }).x) &&
-    isFiniteNumber((obj.position as { y?: unknown }).y)
-      ? { x: (obj.position as { x: number }).x, y: (obj.position as { y: number }).y }
-      : undefined
-
-  let size: { width: number; height: number } | undefined
-  if (
-    obj.size &&
-    typeof obj.size === "object" &&
-    isFiniteNumber((obj.size as { width?: unknown }).width) &&
-    isFiniteNumber((obj.size as { height?: unknown }).height)
-  ) {
-    const width = (obj.size as { width: number }).width
-    const height = (obj.size as { height: number }).height
-    if (width >= MIN_PERSISTED_WIDTH && height >= MIN_PERSISTED_HEIGHT) {
-      size = { width, height }
-    }
-  }
-
-  return { open: obj.open, ...(position ? { position } : {}), ...(size ? { size } : {}) }
+  return { open: obj.open }
 }
 
 export function loadQuickAccessPanels(roomId: string | null): QuickAccessPanelsMap {
@@ -91,29 +47,12 @@ export function loadQuickAccessPanels(roomId: string | null): QuickAccessPanelsM
 
 export function saveQuickAccessPanels(roomId: string | null, panels: QuickAccessPanelsMap): void {
   if (roomId == null || typeof sessionStorage === "undefined") return
-  sessionStorage.setItem(STORAGE_PREFIX + roomId, JSON.stringify(panels))
-}
-
-function countOpenPanels(panels: QuickAccessPanelsMap): number {
-  return Object.values(panels).filter((p) => p.open).length
-}
-
-function cascadePosition(openCount: number): { x: number; y: number } {
-  const offset = openCount * 28
-  return { x: 48 + offset, y: 72 + offset }
-}
-
-function isUsablePosition(position: { x: number; y: number } | undefined): boolean {
-  if (!position) return false
-  if (typeof window === "undefined") return true
-  const { innerWidth, innerHeight } = window
-  // Require at least part of the panel header to remain on-screen.
-  return (
-    position.x > -200 &&
-    position.y > -40 &&
-    position.x < innerWidth - 40 &&
-    position.y < innerHeight - 40
-  )
+  // Persist open flags only (ignore legacy position/size keys if present in older saves).
+  const openOnly: QuickAccessPanelsMap = {}
+  for (const [name, panel] of Object.entries(panels)) {
+    openOnly[name] = { open: panel.open }
+  }
+  sessionStorage.setItem(STORAGE_PREFIX + roomId, JSON.stringify(openOnly))
 }
 
 export const quickAccessPanelsMachine = setup({
@@ -140,29 +79,10 @@ export const quickAccessPanelsMachine = setup({
       if (event.type !== "TOGGLE") return {}
       const { pluginName } = event
       const existing = context.panels[pluginName]
-      if (existing?.open) {
-        return {
-          panels: {
-            ...context.panels,
-            [pluginName]: { ...existing, open: false },
-          },
-        }
-      }
-
-      const openCount = countOpenPanels(context.panels)
-      const storedPosition = existing?.position
-      const position = isUsablePosition(storedPosition)
-        ? storedPosition
-        : cascadePosition(openCount)
-
       return {
         panels: {
           ...context.panels,
-          [pluginName]: {
-            open: true,
-            position,
-            size: existing?.size ?? { ...QUICK_ACCESS_DEFAULT_SIZE },
-          },
+          [pluginName]: { open: !existing?.open },
         },
       }
     }),
@@ -173,27 +93,7 @@ export const quickAccessPanelsMachine = setup({
       return {
         panels: {
           ...context.panels,
-          [event.pluginName]: { ...existing, open: false },
-        },
-      }
-    }),
-    setGeometry: assign(({ context, event }) => {
-      if (event.type !== "SET_GEOMETRY") return {}
-      const existing = context.panels[event.pluginName] ?? { open: true }
-      const nextSize =
-        event.size &&
-        event.size.width >= MIN_PERSISTED_WIDTH &&
-        event.size.height >= MIN_PERSISTED_HEIGHT
-          ? event.size
-          : undefined
-      return {
-        panels: {
-          ...context.panels,
-          [event.pluginName]: {
-            ...existing,
-            ...(event.position ? { position: event.position } : {}),
-            ...(nextSize ? { size: nextSize } : {}),
-          },
+          [event.pluginName]: { open: false },
         },
       }
     }),
@@ -243,9 +143,6 @@ export const quickAccessPanelsMachine = setup({
         },
         CLOSE: {
           actions: ["closePanel", "persistPanels"],
-        },
-        SET_GEOMETRY: {
-          actions: ["setGeometry", "persistPanels"],
         },
         PRUNE: {
           actions: ["prunePanels", "persistPanels"],

--- a/docs/PLUGIN_DEVELOPMENT.md
+++ b/docs/PLUGIN_DEVELOPMENT.md
@@ -19,7 +19,7 @@ Documentation is split into focused guides below. Start with [Getting Started](p
 
 | Guide | Topics |
 | ----- | ------ |
-| [Admin Configuration](plugins/admin-config.md) | Config schema, field types, layout, action buttons |
+| [Admin Configuration](plugins/admin-config.md) | Config schema, field types, layout, action buttons, Quick Access panels (`quickAccess`) |
 | [Plugin Components](plugins/components.md) | Declarative UI, areas, templates, game state tabs |
 
 ### Behavior & Data
@@ -51,4 +51,5 @@ Documentation is split into focused guides below. Start with [Getting Started](p
 - [ADR 0006: Plugin system](adrs/0006-plugin-system-for-room-features.md)
 - [ADR 0042: Game sessions and inventory](adrs/0042-game-sessions-and-inventory.md)
 - [ADR 0057: User personas](adrs/0057-user-personas-system.md)
+- [ADR 0072: Quick Access admin panels](adrs/0072-quick-access-admin-panels.md) — opt-in room FloatingPanels for curated config actions
 - [Backend Development](BACKEND_DEVELOPMENT.md) — server architecture, SystemEvents, broadcasters

--- a/docs/adrs/0072-quick-access-admin-panels.md
+++ b/docs/adrs/0072-quick-access-admin-panels.md
@@ -1,0 +1,32 @@
+# 0072. Quick Access Admin Panels for Plugin Actions
+
+**Date:** 2026-07-21
+**Status:** Accepted
+
+## Context
+
+Plugin run-of-show controls (start/advance/end a quiz, start/end shopping sessions, reveal Guess the Tune fields) live as `type: "action"` elements in `getConfigSchema().layout`. Those actions only appear in the Settings modal today, which is awkward during a live show when multiple admins specialize (one runs the quiz, another manages shops).
+
+Component-schema `adminOnly` buttons (e.g. Guess the Tune in `nowPlayingInfo`) already surface some actions in the room UI, but that path is area-specific and does not cover lifecycle actions that belong with config. We need a schema-driven, admin-only room surface for curated config actions without duplicating action definitions or editing config values mid-panel.
+
+## Decision
+
+1. **Opt-in list on the config schema.** `PluginConfigSchema` may include `quickAccess?: string[]` — action name strings that must match `layout` items with `type: "action"`. Order in `quickAccess` is the panel order. Unknown names are skipped.
+2. **Actions only (v1).** Quick Access panels render those action buttons (including `showWhen` and optional `formFields`) via the existing web `PluginConfigForm` + `EXECUTE_PLUGIN_ACTION` path. Config field editing stays in Settings.
+3. **Enabled filter.** The Quick Access menu lists a plugin only when it has a non-empty resolvable `quickAccess` list **and** `pluginConfigs[name].enabled === true` (same convention as Settings overview).
+4. **Client-only surface.** Open state and desktop FloatingPanel position/size are stored in sessionStorage per room (`quickAccessPanels:{roomId}`). Mobile uses a Dialog and does not persist geometry. Closing a panel retains geometry for reopen; disabling a plugin prunes its record.
+5. **Shared open state.** Because `AdminControls` mounts in multiple places, a room-scoped XState actor owns the panel map; a single host in Overlays renders panels.
+
+## Consequences
+
+- Plugin authors curate run-of-show actions once in `getConfigSchema` without a second component-schema area.
+- Admins can keep multiple plugin panels open across reloads within a session.
+- Trade-off: enabling/disabling a plugin still requires Settings (or another surface); Quick Access deliberately does not edit config.
+- Future work could add scalar config fields to panels; public config is replace-on-write, so any such path must save the full merged plugin config.
+
+## See also
+
+- [ADR 0004](0004-state-machines-for-ui-and-socket-events.md) — UI state machines
+- [ADR 0006](0006-plugin-system-for-room-features.md) — plugin system
+- [ADR 0068](0068-private-scoped-plugin-config-fields.md) — schema-driven config authoring
+- [`docs/plugins/admin-config.md`](../plugins/admin-config.md) — config schema authoring guide

--- a/docs/adrs/0072-quick-access-admin-panels.md
+++ b/docs/adrs/0072-quick-access-admin-panels.md
@@ -12,15 +12,15 @@ Component-schema `adminOnly` buttons (e.g. Guess the Tune in `nowPlayingInfo`) a
 ## Decision
 
 1. **Opt-in list on the config schema.** `PluginConfigSchema` may include `quickAccess?: string[]` — action name strings that must match `layout` items with `type: "action"`. Order in `quickAccess` is the panel order. Unknown names are skipped.
-2. **Actions only (v1).** Quick Access panels render those action buttons (including `showWhen` and optional `formFields`) via the existing web `PluginConfigForm` + `EXECUTE_PLUGIN_ACTION` path. Config field editing stays in Settings.
+2. **Actions only (v1).** Quick Access panels render those action buttons (including `showWhen` and optional `formFields`) via the existing web `PluginConfigForm` + `EXECUTE_PLUGIN_ACTION` path. Config field editing stays in Settings (panels can deep-link there).
 3. **Enabled filter.** The Quick Access menu lists a plugin only when it has a non-empty resolvable `quickAccess` list **and** `pluginConfigs[name].enabled === true` (same convention as Settings overview).
-4. **Client-only surface.** Open state and desktop FloatingPanel position/size are stored in sessionStorage per room (`quickAccessPanels:{roomId}`). Mobile uses a Dialog and does not persist geometry. Closing a panel retains geometry for reopen; disabling a plugin prunes its record.
-5. **Shared open state.** Because `AdminControls` mounts in multiple places, a room-scoped XState actor owns the panel map; a single host in Overlays renders panels.
+4. **Client-only open set.** Which panels are open is stored in sessionStorage per room (`quickAccessPanels:{roomId}`). Desktop FloatingPanels use ephemeral default position/size (cascaded on open); geometry is not persisted. Mobile uses a Dialog. Disabling a plugin prunes its open record.
+5. **Shared open state.** Because `AdminControls` mounts in multiple places, a room-scoped XState actor owns the open map; a single host in memoized `Overlays` renders panels (same stability pattern as schedule-note FloatingPanels under `memo(Sidebar)`).
 
 ## Consequences
 
 - Plugin authors curate run-of-show actions once in `getConfigSchema` without a second component-schema area.
-- Admins can keep multiple plugin panels open across reloads within a session.
+- Admins can keep multiple plugin panels open across reloads within a session; panel placement resets each open.
 - Trade-off: enabling/disabling a plugin still requires Settings (or another surface); Quick Access deliberately does not edit config.
 - Future work could add scalar config fields to panels; public config is replace-on-write, so any such path must save the full merged plugin config.
 

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -77,6 +77,7 @@ This directory contains Architectural Decision Records (ADRs) for the Listening 
 | [0069](0069-playback-controller-volume-and-before-play-hook.md) | Playback Controller volume and beforePlayQueuedTrack hook | Accepted |
 | [0070](0070-route-transitions-via-view-transitions-api.md) | Route transitions via View Transitions API | Accepted |
 | [0071](0071-admin-platform-identity-for-room-creation.md) | Admin platform identity for room creation (no Spotify create gate) | Accepted |
+| [0072](0072-quick-access-admin-panels.md) | Quick Access admin panels for plugin actions | Accepted |
 
 ## Creating a New ADR
 

--- a/docs/plugins/admin-config.md
+++ b/docs/plugins/admin-config.md
@@ -213,7 +213,7 @@ getConfigSchema(): PluginConfigSchema {
 }
 ```
 
-The menu only lists plugins that declare `quickAccess` **and** have `enabled: true` in room config. Panels are actions-only (no config field editing). Open state and desktop panel position/size persist in sessionStorage per room.
+The menu only lists plugins that declare `quickAccess` **and** have `enabled: true` in room config. Panels are actions-only (no config field editing). Which panels are open persists in sessionStorage per room; desktop position/size is ephemeral.
 
 ### Handling Actions
 

--- a/docs/plugins/admin-config.md
+++ b/docs/plugins/admin-config.md
@@ -183,6 +183,38 @@ getConfigSchema(): PluginConfigSchema {
 | `showWhen`       | `object` | No       | Conditional visibility (same as field `showWhen`)                                               |
 | `formFields`     | `array`  | No       | Optional fields shown in a popover before run; values are passed as `params` to `executeAction` |
 
+### Quick Access Panels
+
+Opt run-of-show actions into the room **Quick Access** menu (admin-only FloatingPanels) by listing their action names on the schema (see [ADR 0072](../adrs/0072-quick-access-admin-panels.md)):
+
+```typescript
+getConfigSchema(): PluginConfigSchema {
+  return {
+    jsonSchema: z.toJSONSchema(myConfigSchema),
+    layout: [
+      "enabled",
+      {
+        type: "action",
+        action: "startSession",
+        label: "Start session",
+        showWhen: { field: "enabled", value: true },
+      },
+      {
+        type: "action",
+        action: "endSession",
+        label: "End session",
+        showWhen: { field: "enabled", value: true },
+      },
+    ],
+    fieldMeta: { /* ... */ },
+    // Action names from layout — order is panel order
+    quickAccess: ["startSession", "endSession"],
+  }
+}
+```
+
+The menu only lists plugins that declare `quickAccess` **and** have `enabled: true` in room config. Panels are actions-only (no config field editing). Open state and desktop panel position/size persist in sessionStorage per room.
+
 ### Handling Actions
 
 Override the `executeAction` method to handle action button clicks. When `formFields` are defined, the admin UI collects values and sends them as the third argument (`params`):

--- a/packages/plugin-config-ui/src/index.ts
+++ b/packages/plugin-config-ui/src/index.ts
@@ -10,4 +10,6 @@ export {
   updateRow,
   moveRow,
   getItemJsonSchema,
+  getQuickAccessActions,
+  getQuickAccessSchema,
 } from "./logic"

--- a/packages/plugin-config-ui/src/logic.test.ts
+++ b/packages/plugin-config-ui/src/logic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import type { PluginFieldMeta } from "@repo/types/Plugin"
+import type { PluginActionElement, PluginConfigSchema, PluginFieldMeta } from "@repo/types/Plugin"
 import {
   shouldShow,
   emptyRow,
@@ -8,6 +8,8 @@ import {
   updateRow,
   moveRow,
   getItemJsonSchema,
+  getQuickAccessActions,
+  getQuickAccessSchema,
 } from "./logic"
 
 describe("shouldShow (nested scope)", () => {
@@ -101,5 +103,47 @@ describe("getItemJsonSchema (nested enum resolution)", () => {
   it("returns empty object when items are not described", () => {
     expect(getItemJsonSchema({ properties: { questions: {} } }, "questions")).toEqual({})
     expect(getItemJsonSchema({}, "missing")).toEqual({})
+  })
+})
+
+describe("getQuickAccessActions", () => {
+  const startAction: PluginActionElement = {
+    type: "action",
+    action: "startSession",
+    label: "Start",
+  }
+  const advanceAction: PluginActionElement = {
+    type: "action",
+    action: "advanceQuestion",
+    label: "Advance",
+  }
+  const endAction: PluginActionElement = {
+    type: "action",
+    action: "endSession",
+    label: "End",
+  }
+
+  const schema: PluginConfigSchema = {
+    jsonSchema: {},
+    layout: ["enabled", startAction, advanceAction, endAction],
+    fieldMeta: {
+      enabled: { type: "boolean", label: "Enable" },
+    },
+    quickAccess: ["advanceQuestion", "startSession", "missingAction"],
+  }
+
+  it("returns empty array when quickAccess is missing or empty", () => {
+    expect(getQuickAccessActions({ ...schema, quickAccess: undefined })).toEqual([])
+    expect(getQuickAccessActions({ ...schema, quickAccess: [] })).toEqual([])
+  })
+
+  it("returns actions in quickAccess order and skips unknown names", () => {
+    expect(getQuickAccessActions(schema)).toEqual([advanceAction, startAction])
+  })
+
+  it("builds a filtered schema for panel rendering", () => {
+    const filtered = getQuickAccessSchema(schema)
+    expect(filtered?.layout).toEqual([advanceAction, startAction])
+    expect(getQuickAccessSchema({ ...schema, quickAccess: ["nope"] })).toBeNull()
   })
 })

--- a/packages/plugin-config-ui/src/logic.ts
+++ b/packages/plugin-config-ui/src/logic.ts
@@ -1,4 +1,9 @@
-import type { PluginFieldMeta, ShowWhenCondition } from "@repo/types/Plugin"
+import type {
+  PluginActionElement,
+  PluginConfigSchema,
+  PluginFieldMeta,
+  ShowWhenCondition,
+} from "@repo/types/Plugin"
 
 /**
  * Check if an element should be visible based on its showWhen condition(s).
@@ -93,4 +98,42 @@ export function getItemJsonSchema(
   const properties = jsonSchema.properties as Record<string, any> | undefined
   const items = properties?.[arrayFieldName]?.items
   return items && typeof items === "object" ? (items as Record<string, unknown>) : {}
+}
+
+/**
+ * Resolve Quick Access action elements from a config schema (ADR 0072).
+ * Returns `type: "action"` layout items whose `action` is listed in `quickAccess`,
+ * ordered by the `quickAccess` array. Unknown action names are skipped.
+ */
+export function getQuickAccessActions(schema: PluginConfigSchema): PluginActionElement[] {
+  const names = schema.quickAccess
+  if (!names?.length) return []
+
+  const byAction = new Map<string, PluginActionElement>()
+  for (const item of schema.layout) {
+    if (typeof item === "object" && item.type === "action") {
+      byAction.set(item.action, item)
+    }
+  }
+
+  const result: PluginActionElement[] = []
+  for (const name of names) {
+    const action = byAction.get(name)
+    if (action) result.push(action)
+  }
+  return result
+}
+
+/**
+ * Build a config schema whose `layout` is only the Quick Access actions (for panel rendering).
+ */
+export function getQuickAccessSchema(schema: PluginConfigSchema): PluginConfigSchema | null {
+  const actions = getQuickAccessActions(schema)
+  if (actions.length === 0) return null
+  return {
+    jsonSchema: schema.jsonSchema,
+    fieldMeta: schema.fieldMeta,
+    layout: actions,
+    quickAccess: schema.quickAccess,
+  }
 }

--- a/packages/plugin-guess-the-tune/schema.ts
+++ b/packages/plugin-guess-the-tune/schema.ts
@@ -326,5 +326,6 @@ export function getConfigSchema(): PluginConfigSchema {
         showWhen: { field: "enabled", value: true },
       },
     },
+    quickAccess: ["revealTitle", "revealArtist", "revealAlbum", "revealAll", "resetLeaderboard"],
   }
 }

--- a/packages/plugin-item-shops/index.ts
+++ b/packages/plugin-item-shops/index.ts
@@ -365,6 +365,7 @@ export class ItemShopsPlugin extends BasePlugin<ItemShopsConfig> {
           showWhen: { field: "enabled", value: true },
         },
       },
+      quickAccess: ["startShoppingSession", "endShoppingSessions"],
     }
   }
 

--- a/packages/plugin-quiz-sessions/schema.ts
+++ b/packages/plugin-quiz-sessions/schema.ts
@@ -200,5 +200,6 @@ export function getConfigSchema(): PluginConfigSchema {
         ],
       },
     },
+    quickAccess: ["startSession", "advanceQuestion", "endSession"],
   }
 }

--- a/packages/types/Plugin.ts
+++ b/packages/types/Plugin.ts
@@ -176,6 +176,11 @@ export interface PluginConfigSchema {
   layout: (string | PluginSchemaElement | PluginActionElement)[]
   /** Field-specific UI hints not captured in JSON Schema */
   fieldMeta: Record<string, PluginFieldMeta>
+  /**
+   * Action names from `layout` to surface in room Quick Access admin panels (ADR 0072).
+   * Each entry must match a `type: "action"` layout element's `action` id.
+   */
+  quickAccess?: string[]
 }
 
 /**


### PR DESCRIPTION
Adds the ability for plugins to designate actions for "quick access", letting admins open up a FloatingPanels for plugins for easy access to plugin actions.


https://github.com/user-attachments/assets/97b735c6-0e1e-4fab-b0dc-e3f560171b6e

